### PR TITLE
Removed un-necessary conversion  to number of resources id

### DIFF
--- a/forms-flow-admin/src/components/dashboard/dashboard.tsx
+++ b/forms-flow-admin/src/components/dashboard/dashboard.tsx
@@ -77,7 +77,7 @@ export const InsightDashboard = React.memo((props: any) => {
 
   const updateAuthList = (authorizations) => {
     let newList = [...authorizations];
-    let authIds = newList.map((item) => Number(item.resourceId));
+    let authIds = newList.map((item) => item.resourceId);
     for (let item of dashboards?.results) {
       if (!authIds.includes(item.id)) {
         let obj = {


### PR DESCRIPTION
The admin dashboard where showing an unexpected row due to a comparison issue issue in the code. 
https://aottech.atlassian.net/browse/FWF-3063
![image](https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/assets/83585487/0fbbf532-4bce-46ac-be05-e77be7fecd0b)

changed:
![image](https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/assets/83585487/392cc352-3372-4eb0-a962-c327078afe52)
