### PR TITLE
FWF-3739 [Bugfix] Height commented for common modal dialog as it is breaking settings modal layout

### DIFF
--- a/forms-flow-theme/scss/_modal.scss
+++ b/forms-flow-theme/scss/_modal.scss
@@ -4,7 +4,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100vh;
+  // height: 100vh;
   margin: auto;
   min-height: auto;
   // margin: 8.75rem auto !important; // Full height of the viewport


### PR DESCRIPTION

# Issue Tracking

JIRA: 
Issue Type: BUG

# Changes

Height commented for common modal dialog as it is breaking settings modal layout

Before : 
<img width="872" alt="Screenshot 2024-10-15 at 1 47 30 PM" src="https://github.com/user-attachments/assets/04d116e1-b95f-44a5-a21a-2aa652b8227d">


After : 
<img width="872" alt="Screenshot 2024-10-15 at 1 48 32 PM" src="https://github.com/user-attachments/assets/053bd39c-df64-438d-8018-30b0b2c0b600">

