### PR TITLE
FWF-3971:[Feature]-Disable import modal's primary button.

### DIFF
--- a/forms-flow-components/src/components/CustomComponents/ImportModal.tsx
+++ b/forms-flow-components/src/components/CustomComponents/ImportModal.tsx
@@ -94,7 +94,6 @@ export const ImportModal: React.FC<ImportModalProps> = React.memo(
 
     const [showFileItems, setShowFileItems] = useState(false);
     const [inprogress, setInprogress] = useState(true);
-    const [primaryButtonDisabled, setPrimaryButtonDisabled] = useState(true);
 
     const layoutOptions = [
       { value: true, label: "Skip, do not import" },
@@ -160,25 +159,16 @@ export const ImportModal: React.FC<ImportModalProps> = React.memo(
       }
     };
 
-    useEffect(() => {
-      const shouldDisablePrimaryButton = 
-        !selectedFile || inprogress || importLoader ||
-        (importError && primaryButtonText !== "Try Again") || 
-        (showFileItems && 
-          selectedFlowVersion?.label === skipImport && 
-          selectedLayoutVersion?.label === skipImport);
+
+    const primaryButtonDisabled = 
+      !selectedFile || 
+      inprogress || 
+      importLoader ||
+      (importError && primaryButtonText !== "Try Again") || 
+      (showFileItems && 
+        selectedFlowVersion?.label === skipImport && 
+        selectedLayoutVersion?.label === skipImport);
     
-      setPrimaryButtonDisabled(shouldDisablePrimaryButton);
-    }, [
-      showFileItems,
-      selectedFlowVersion,
-      selectedLayoutVersion,
-      selectedFile,
-      importError,
-      primaryButtonText,
-      importLoader,
-      inprogress
-    ]);
 
     useEffect(() => {
       if (

--- a/forms-flow-components/src/components/CustomComponents/ImportModal.tsx
+++ b/forms-flow-components/src/components/CustomComponents/ImportModal.tsx
@@ -76,16 +76,25 @@ export const ImportModal: React.FC<ImportModalProps> = React.memo(
     const redColor = computedStyle.getPropertyValue("--ff-red-000");
     const [selectedFile, setSelectedFile] = useState<File | null>(null);
     const [uploadProgress, setUploadProgress] = useState(0);
+    const skipImport = "Skip, do not import";
     const [selectedLayoutVersion, setSelectedLayoutVersion] = useState<{
       value: any;
       label: string;
-    } | null>(null);
+    } | null>({
+      value: true,
+      label: skipImport,
+    });
     const [selectedFlowVersion, setSelectedFlowVersion] = useState<{
       value: any;
       label: string;
-    } | null>(null);
+    } | null>({
+      value: true,
+      label: skipImport,
+    });
+
     const [showFileItems, setShowFileItems] = useState(false);
     const [inprogress, setInprogress] = useState(true);
+    const [primaryButtonDisabled, setPrimaryButtonDisabled] = useState(true);
 
     const layoutOptions = [
       { value: true, label: "Skip, do not import" },
@@ -97,7 +106,9 @@ export const ImportModal: React.FC<ImportModalProps> = React.memo(
       },
       {
         value: "minor",
-        label: `import as version ${fileItems?.form?.majorVersion}.${fileItems?.form?.minorVersion + 1 }  (impacts previous and new submissions)`,
+        label: `import as version ${fileItems?.form?.majorVersion}.${
+          fileItems?.form?.minorVersion + 1
+        }  (impacts previous and new submissions)`,
       },
     ];
 
@@ -148,6 +159,26 @@ export const ImportModal: React.FC<ImportModalProps> = React.memo(
         );
       }
     };
+
+    useEffect(() => {
+      const shouldDisablePrimaryButton = 
+        !selectedFile || inprogress || importLoader ||
+        (importError && primaryButtonText !== "Try Again") || 
+        (showFileItems && 
+          selectedFlowVersion?.label === skipImport && 
+          selectedLayoutVersion?.label === skipImport);
+    
+      setPrimaryButtonDisabled(shouldDisablePrimaryButton);
+    }, [
+      showFileItems,
+      selectedFlowVersion,
+      selectedLayoutVersion,
+      selectedFile,
+      importError,
+      primaryButtonText,
+      importLoader,
+      inprogress
+    ]);
 
     useEffect(() => {
       if (
@@ -508,12 +539,7 @@ export const ImportModal: React.FC<ImportModalProps> = React.memo(
                 ? "dark"
                 : "primary"
             }
-            disabled={
-              inprogress || 
-              importLoader ||
-              !selectedFile ||
-              (importError && primaryButtonText !== "Try Again")
-            }
+            disabled={ primaryButtonDisabled }
             size="md"
             label={primaryButtonText}
             onClick={() => {


### PR DESCRIPTION
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-3971
Issue Type: BUG/ FEATURE

# Changes
The import button will be disabled if no versions are selected and chose both form and wrokflow as Skip, do not import. 
![image](https://github.com/user-attachments/assets/2bf8938e-26f6-419a-b89f-a93038f5b788)
![image](https://github.com/user-attachments/assets/7b5580b0-b133-4c3f-832d-bc50083c9eec)
