### PR TITLE
FWF-4647: [Modified] Added All tasks data, if no filter present, removed no selected filter text

### DIFF
--- a/forms-flow-review/src/components/TaskList/TaskFilterDropdown.tsx
+++ b/forms-flow-review/src/components/TaskList/TaskFilterDropdown.tsx
@@ -36,7 +36,8 @@ const TaskListDropdownItems = memo(() => {
   const [showReorderFilterModal,setShowReorderFilterModal] = useState(false); 
   
   const handleEditTaskFilter = () => {
-    if (!selectedFilter) return;
+    // Prevent editing if the active filter is the initial "All Tasks".
+    if (!selectedFilter || (!isUnsavedFilter && filterList.length === 0)) return;
     dispatch(setFilterToEdit(selectedFilter));
     setShowTaskFilterModal(true);
   };
@@ -156,16 +157,20 @@ const changeFilterSelection = (filter) => {
     return filterDropdownItemsArray;
   }, [filtersAndCount, defaultFilter,filterList,userDetails ]);
 
+// filter title based on unsaved filter, empty list or selected filter
   let title;
 
-if (filterList.length === 0) {
-  title = t("All Tasks");
-} else if (selectedFilter) {
-  const filterName = isUnsavedFilter ? t("Unsaved Filter") : t(selectedFilter.name);
-  title = `${filterName} (${tasksCount ?? 0})`;
-} else {
-  title = t("Select Filter");
-}
+  if (selectedFilter) {
+    if (isUnsavedFilter) {
+      title = t("Unsaved Filter");
+    }
+    else if (filterList.length === 0) {
+      title = t("All Tasks");
+    } else {
+      title = `${selectedFilter.name} (${tasksCount ?? 0})`;
+    }
+  }
+  
 
   return (
     <>

--- a/forms-flow-review/src/components/TaskList/TaskFilterDropdown.tsx
+++ b/forms-flow-review/src/components/TaskList/TaskFilterDropdown.tsx
@@ -54,8 +54,7 @@ const changeFilterSelection = (filter) => {
 
   //if selecetd filter is not in filter list, then select All tasks filter
   const upcomingFilter =
-    filterList.find(item => item.id === filter?.id) ||
-    filterList.find(item => item.name === "All tasks"); 
+    filterList.find(item => item.id === filter?.id)  
 
   if (!upcomingFilter) return;
 
@@ -157,7 +156,7 @@ const changeFilterSelection = (filter) => {
     return filterDropdownItemsArray;
   }, [filtersAndCount, defaultFilter,filterList,userDetails ]);
 
-  const title = selectedFilter
+  const title = filterList.length === 0 ? t("All Tasks") : selectedFilter
     ? `${isUnsavedFilter ? t("Unsaved Filter") : t(selectedFilter.name)} (${
         tasksCount ?? 0
       })`

--- a/forms-flow-review/src/components/TaskList/TaskFilterDropdown.tsx
+++ b/forms-flow-review/src/components/TaskList/TaskFilterDropdown.tsx
@@ -156,11 +156,17 @@ const changeFilterSelection = (filter) => {
     return filterDropdownItemsArray;
   }, [filtersAndCount, defaultFilter,filterList,userDetails ]);
 
-  const title = filterList.length === 0 ? t("All Tasks") : selectedFilter
-    ? `${isUnsavedFilter ? t("Unsaved Filter") : t(selectedFilter.name)} (${
-        tasksCount ?? 0
-      })`
-    : t("Select Filter");
+  let title;
+
+if (filterList.length === 0) {
+  title = t("All Tasks");
+} else if (selectedFilter) {
+  const filterName = isUnsavedFilter ? t("Unsaved Filter") : t(selectedFilter.name);
+  title = `${filterName} (${tasksCount ?? 0})`;
+} else {
+  title = t("Select Filter");
+}
+
   return (
     <>
       <ButtonDropdown

--- a/forms-flow-review/src/components/TaskList/TaskList.tsx
+++ b/forms-flow-review/src/components/TaskList/TaskList.tsx
@@ -34,7 +34,6 @@ import { HelperServices } from "@formsflow/service";
 import AttributeFilterDropdown from "./AttributeFilterDropdown";
 import { createReqPayload } from "../../helper/taskHelper";
 import { optionSortBy } from "../../helper/tableHelper";
-import {  UserDetail } from "../../types/taskFilter";
 import  useAllTasksPayload  from "../../constants/allTasksPayload";
 
 const TaskList = () => {
@@ -53,12 +52,9 @@ const TaskList = () => {
     selectedAttributeFilter,
     isAssigned,
     filterList,
-    filterToEdit
-  } = useSelector((state: RootState) => state.task);
-    const userDetails: UserDetail = useSelector((state:RootState)=> state.task.userDetails);
-  
+  } = useSelector((state: RootState) => state.task);  
 
-   const allTasksPayload = useAllTasksPayload();
+  const allTasksPayload = useAllTasksPayload();
   const [showSortModal, setShowSortModal] = useState(false);
  
   //inital data loading

--- a/forms-flow-review/src/components/TaskList/TasklistTable.tsx
+++ b/forms-flow-review/src/components/TaskList/TasklistTable.tsx
@@ -264,15 +264,6 @@ const TaskListTable = () => {
     </td>
   );
 
-  // Conditional Renders
-  const renderNoFilterSelected = () => (
-    <div
-      data-testid="no-filter-selected"
-      aria-label={t("No filter selected message")}
-    >
-      {t("No filter selected.")}
-    </div>
-  );
 
   const renderEmptyTable = () => (
     <div
@@ -377,10 +368,7 @@ const TaskListTable = () => {
     </table>
   );
 
-  // Main Render Logic
-  if (!selectedFilter) {
-    return renderNoFilterSelected();
-  }
+
 
   if (columns.length === 0) {
     return renderEmptyTable();

--- a/forms-flow-review/src/constants/allTasksPayload.ts
+++ b/forms-flow-review/src/constants/allTasksPayload.ts
@@ -1,0 +1,29 @@
+import { useSelector } from "react-redux";
+import { UserDetail } from "../types/taskFilter";
+import { defaultTaskVariable } from "./defaultTaskVariable";
+import { RootState } from "../reducers";
+
+const useAllTasksPayload = () => {
+  const userDetails: UserDetail = useSelector((state: RootState) => state.task.userDetails);
+
+  return {
+    name: "All Tasks",
+    criteria: {
+      includeAssignedTasks: true,
+      candidateGroupsExpression: "${currentUserGroups()}",
+      sorting: [
+        {
+          sortBy: "dueDate",
+          sortOrder: "asc",
+        },
+      ],
+    },
+    variables: defaultTaskVariable,
+    properties: {},
+    roles: [],
+    users: [userDetails.preferred_username],
+    filterType: "TASK",
+  };
+};
+
+export default useAllTasksPayload;


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-4647
Issue Type: BUG/ FEATURE

# Changes
* Added All Tasks data as response if no filter in list
* Removed no selected filter text
* Added a constants file for "All Tasks" paylaod


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce All Tasks payload for empty filters

- Default to All Tasks when no filter exists

- Update dropdown title to show All Tasks

- Remove no-filter selected message in table


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TaskFilterDropdown.tsx</strong><dd><code>Handle All Tasks in filter dropdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/TaskList/TaskFilterDropdown.tsx

<li>Prevent editing initial All Tasks filter<br> <li> Remove name-based fallback filter selection<br> <li> Add title logic for All Tasks when filter list empty


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/597/files#diff-a03f00f76672e0a153e6860b7b5eff4159d8cd08f8372bea8515e3afb1fd08bd">+18/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TaskList.tsx</strong><dd><code>Integrate All Tasks payload in TaskList</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/TaskList/TaskList.tsx

<li>Import and use useAllTasksPayload hook<br> <li> Set All Tasks payload when no filters returned<br> <li> Select All Tasks as default if none exists<br> <li> Add effect to fetch tasks on filterList change


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/597/files#diff-3221889bf11f45c8e00966371ed295a8227c658328d9258d144524d22634d665">+64/-38</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>allTasksPayload.ts</strong><dd><code>Add allTasksPayload hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/constants/allTasksPayload.ts

<li>Create useAllTasksPayload hook file<br> <li> Define default "All Tasks" query payload


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/597/files#diff-743cb25e44e09a4216d33a896cbdb31b62f610b8aa41c2b6f922e4fb5acf3768">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TasklistTable.tsx</strong><dd><code>Remove no-filter selected message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/TaskList/TasklistTable.tsx

<li>Remove renderNoFilterSelected fallback<br> <li> Always render table or empty state views


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/597/files#diff-8174abb611ee4ca2991835c9d9808bccfd09c8539aee8301cee367477b588564">+1/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>