### PR TITLE
FWF-4820: [BugFix] filter share icon conditions updated

### DIFF
--- a/forms-flow-review/src/components/ReorderTaskFilterModal.tsx
+++ b/forms-flow-review/src/components/ReorderTaskFilterModal.tsx
@@ -41,14 +41,18 @@ export const ReorderTaskFilterModal: React.FC<ReorderTaskFilterModalProps> =
         return filtersList.map((item) => {
           const createdByMe = userDetails.preferred_username === item.createdBy;
           const isSharedToPublic = !item.roles?.length && !item.users?.length;
+          const isSharedToRoles = item.roles.length
           const isShareToMe = item.roles?.some((role) =>
             userDetails.groups?.includes(role)
           );
           let icon = null;
-          if (createdByMe) {
+          if (createdByMe&& (isSharedToPublic || isSharedToRoles)) {
             icon = <SharedWithOthersIcon />;
           } else if (isSharedToPublic || isShareToMe) {
             icon = <SharedWithMeIcon />;
+          }
+          else if (item?.name === "All Tasks") {
+          icon = null;
           }
           return {
             id: item.id,

--- a/forms-flow-review/src/components/TaskList/TaskFilterDropdown.tsx
+++ b/forms-flow-review/src/components/TaskList/TaskFilterDropdown.tsx
@@ -121,14 +121,18 @@ const onSearch = (searchTerm: string) => {
       if(filterDetails){
         const createdByMe =userDetails?.preferred_username === filterDetails?.createdBy;
         const isSharedToPublic =!filterDetails?.roles?.length && !filterDetails?.users?.length;
+        const isSharedToRoles = filterDetails?.roles.length
         const isSharedToMe = filterDetails?.roles?.some((role) =>
           userDetails?.groups?.includes(role)
         );
 
-        if (createdByMe) {
+        if (createdByMe && (isSharedToPublic || isSharedToRoles)) {
           icon = <SharedWithOthersIcon className="shared-icon" />;
         } else if (isSharedToPublic || isSharedToMe) {
           icon = <SharedWithMeIcon className="shared-icon" />;
+        }
+        else if (filterDetails?.name === "All Tasks") {
+          icon = null;
         }
    
       return { 


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-4820
Issue Type: BUG/ FEATURE

# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->


___

### **PR Type**
Bug fix


___

### **Description**
Add `isSharedToRoles` check for role-shared filters
Restrict SharedWithOthersIcon to created-by-me with public or role sharing
Preserve SharedWithMeIcon for public or group-shared filters
Apply fixes in reorder modal and filter dropdown


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ReorderTaskFilterModal.tsx</strong><dd><code>Refine share icon logic in reorder modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/ReorderTaskFilterModal.tsx

Introduce <code>isSharedToRoles</code> flag for role sharing<br> Constrain <br>SharedWithOthersIcon to public or role-shared when createdByMe<br> Retain <br>SharedWithMeIcon logic for public or group-shared filters


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/616/files#diff-09178ad8dc906ee1e92d7c01153a5249f480642999519db29a6fd0515739ed3c">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TaskFilterDropdown.tsx</strong><dd><code>Refine share icon logic in filter dropdown</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/TaskList/TaskFilterDropdown.tsx

Introduce <code>isSharedToRoles</code> flag for role sharing<br> Constrain <br>SharedWithOthersIcon to public or role-shared when createdByMe<br> Ensure <br>SharedWithMeIcon consistent for public or group-shared filters


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/616/files#diff-a03f00f76672e0a153e6860b7b5eff4159d8cd08f8372bea8515e3afb1fd08bd">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>