### PR TITLE
FWF-4820: [Modified] Private update modal, notes criteria

### DIFF
--- a/forms-flow-review/src/components/AttributeFilterModal/AttributeFIlterModalBody.tsx
+++ b/forms-flow-review/src/components/AttributeFilterModal/AttributeFIlterModalBody.tsx
@@ -30,7 +30,7 @@ import { Filter, FilterCriteria } from "../../types/taskFilter";
 import { removeTenantKey, trimFirstSlash } from "../../helper/helper";
 import { RootState } from "../../reducers";
 
-const AttributeFilterModalBody = ({ onClose, toggleUpdateModal, updateSuccess, toggleDeleteModal,deleteSuccess }) => {
+const AttributeFilterModalBody = ({ onClose, toggleUpdateModal, updateSuccess, toggleDeleteModal,deleteSuccess, handleSaveFilterAttributes }) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const filterNameLength = 50;
@@ -386,9 +386,15 @@ const saveButtonVariant = saveSuccess.showSuccess ? "success" : "secondary";
 
 
     const handleUpdateModalClick =()=>{
-      dispatch(setAttributeFilterToEdit(createAttributeFilterPayload()))
+       const isPrivate = attributeFilter.users.length!==0;
+    const data = createAttributeFilterPayload();
+    if(isPrivate){
+     handleSaveFilterAttributes(isPrivate,data);
+    }else{
+        dispatch(setAttributeFilterToEdit(createAttributeFilterPayload()))
       toggleUpdateModal();
-      // need to integrate count down for success
+    }
+    
      }
     const handleDeleteClick = ()=>{
             dispatch(setAttributeFilterToEdit(createAttributeFilterPayload()))

--- a/forms-flow-review/src/components/AttributeFilterModal/AttributeFilterModal.tsx
+++ b/forms-flow-review/src/components/AttributeFilterModal/AttributeFilterModal.tsx
@@ -35,6 +35,10 @@ export const AttributeFilterModal = ({ show, onClose, toggleModal }) => {
   const attributeFilterList = useSelector((state:RootState)=>state.task.attributeFilterList);
   const selectedTaskFilter = useSelector((state:RootState)=>state.task.selectedFilter );
   
+   interface handleSaveFilterAttributes {
+    isPrivate?: boolean;
+    data?: any;
+  }
   const toggleUpdateModal = () => {
     toggleModal();
     setShowUpdateModal((prev) => !prev);
@@ -50,11 +54,12 @@ export const AttributeFilterModal = ({ show, onClose, toggleModal }) => {
 
  
 
-  const handleSaveFilterAttributes = async () => {
-    toggleUpdateModal();
+  const handleSaveFilterAttributes = async (isPrivate?: boolean, data?: any) => {  
+    if(!isPrivate)toggleUpdateModal();
+    const payload = data ?? attributeFilterToEdit;
     const response = await updateFilter(
-      attributeFilterToEdit,
-      attributeFilterToEdit?.id
+      payload,
+      payload?.id
     );
     setUpdateSuccess(onClose, 2);
     const filterList = attributeFilterList.filter((item) => item.id !== response.data.id);
@@ -103,6 +108,7 @@ export const AttributeFilterModal = ({ show, onClose, toggleModal }) => {
           deleteSuccess={deleteSuccess}
           toggleUpdateModal={toggleUpdateModal}
           toggleDeleteModal={toggleDeleteModal}
+          handleSaveFilterAttributes={handleSaveFilterAttributes}
         />
       </Modal>
       {showUpdateModal && (
@@ -123,7 +129,7 @@ export const AttributeFilterModal = ({ show, onClose, toggleModal }) => {
           onClose={toggleUpdateModal}
           primaryBtnText={t("No, Cancel Changes")}
           secondaryBtnText={t("Yes, Update This Filter For Everybody")}
-          secondaryBtnAction={handleSaveFilterAttributes}
+          secondaryBtnAction={() => {handleSaveFilterAttributes();}}
           secondoryBtndataTestid="confirm-attribute-revert-button"
         />
       )}

--- a/forms-flow-review/src/components/AttributeFilterModal/Notes.tsx
+++ b/forms-flow-review/src/components/AttributeFilterModal/Notes.tsx
@@ -6,8 +6,9 @@ import { RootState } from "../../reducers";
 const RenderOwnerShipNotes = ({isCreator, attributeFilter}) => {
   const { t } = useTranslation();
   const isUnsavedFilter = useSelector((state:RootState)=>state.task.isUnsavedFilter);
-  
-  if (isCreator) {
+
+  if(attributeFilter){
+    if (isCreator ) {
     return (
       <div className="pb-4">
         <CustomInfo
@@ -19,6 +20,8 @@ const RenderOwnerShipNotes = ({isCreator, attributeFilter}) => {
       </div>
     );
   }
+  }
+  
 
   if (isUnsavedFilter) {
     return (
@@ -35,7 +38,9 @@ const RenderOwnerShipNotes = ({isCreator, attributeFilter}) => {
     );
   }
 
-  if (!isCreator) {
+  
+if(attributeFilter){
+if (!isCreator) {
     return (
       <div className="pb-4">
         <CustomInfo
@@ -49,6 +54,8 @@ const RenderOwnerShipNotes = ({isCreator, attributeFilter}) => {
       </div>
     );
   }
+}
+  
   return null;
 };
 

--- a/forms-flow-review/src/components/TaskFilterModal/TaskFilterModal.tsx
+++ b/forms-flow-review/src/components/TaskFilterModal/TaskFilterModal.tsx
@@ -50,6 +50,11 @@ const TaskFilterModal = ({ show, onClose, toggleModal }) => {
     startSuccessCountdown: setDeleteSuccess,
   } = useSuccessCountdown();
 
+    interface handleFilterUpdate {
+    isPrivate?: boolean;
+    data?: any;
+  }
+
   const toggleUpdateModal = () => {
     toggleModal();
     setShowUpdateModal((prev) => !prev);
@@ -87,9 +92,10 @@ const TaskFilterModal = ({ show, onClose, toggleModal }) => {
     }
   };
 
-  const handleFilterUpdate = async () => {
-    toggleUpdateModal();
-    const response = await updateFilter(filterToEdit, filterToEdit?.id);
+  const handleFilterUpdate = async (isPrivate?: boolean, data?: any) => { 
+    if(!isPrivate)toggleUpdateModal();
+    const payload = data ?? filterToEdit;
+    const response = await updateFilter(payload, payload?.id);
     setUpdateSuccess(onClose, 2);
     dispatch(setIsUnsavedFilter(false));
     const filtersList = filterList.filter(
@@ -141,6 +147,7 @@ const TaskFilterModal = ({ show, onClose, toggleModal }) => {
           showTaskFilterMainModal={show}
           closeTaskFilterMainModal={onClose}
           filterToEdit={filterToEdit}
+          handleFilterUpdate={handleFilterUpdate}
         />
       </Modal>
 
@@ -186,7 +193,7 @@ const TaskFilterModal = ({ show, onClose, toggleModal }) => {
           onClose={toggleUpdateModal}
           primaryBtnText={t("No, Cancel Changes")}
           secondaryBtnText={t("Yes, Update This Filter For Everybody")}
-          secondaryBtnAction={handleFilterUpdate}
+          secondaryBtnAction={()=>{handleFilterUpdate();}}
           secondoryBtndataTestid="confirm-revert-button"
         />
       )}

--- a/forms-flow-review/src/components/TaskFilterModal/TaskFilterModalBody.tsx
+++ b/forms-flow-review/src/components/TaskFilterModal/TaskFilterModalBody.tsx
@@ -52,6 +52,7 @@ const TaskFilterModalBody = ({
   filterToEdit,
   deleteSuccess,
   updateSuccess,
+  handleFilterUpdate
 }) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
@@ -386,8 +387,14 @@ const TaskFilterModalBody = ({
   };
 
   const handleUpdateModalClick = () => {
-    dispatch(setFilterToEdit(getData()));
+    const isPrivate = filterToEdit.users.length!==0;
+    const data = getData();
+    if(isPrivate){
+     handleFilterUpdate(isPrivate,data);
+    }else{
+      dispatch(setFilterToEdit(getData()));
     toggleUpdateModal();
+    }
   };
   const handleDeleteClick = () => {
     dispatch(setFilterToEdit(getData()));


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-4820
Issue Type: BUG/ FEATURE

# Changes
*  Updated modal if the filter is private
*  notes condition updated


___

### **PR Type**
Enhancement


___

### **Description**
- Introduce private filter update handling

- Parameterize save/update handlers with privacy flag

- Bypass confirmation modal for private filters

- Add null checks in ownership notes component


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AttributeFIlterModalBody.tsx</strong><dd><code>Conditional private filter update handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/AttributeFilterModal/AttributeFIlterModalBody.tsx

<li>Added <code>handleSaveFilterAttributes</code> prop to component<br> <li> Detect <code>isPrivate</code> to route updates differently<br> <li> Bypass <code>toggleUpdateModal</code> for private filters


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/636/files#diff-b021bf706f401cb6d9da5f2772eaa356cb1ad49ba57e4a01b0969ead7c1f4afa">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AttributeFilterModal.tsx</strong><dd><code>Implement save handler for private filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/AttributeFilterModal/AttributeFilterModal.tsx

<li>Defined <code>handleSaveFilterAttributes</code> interface and prop<br> <li> Modified handler to accept <code>isPrivate</code> and <code>data</code> args<br> <li> Conditionally toggle modal based on privacy flag<br> <li> Passed handler to <code>ConfirmModal</code> secondary action


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/636/files#diff-4cb40a4e158c242600418d05458f1055db40e67e090c961729228b22233090b0">+11/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TaskFilterModal.tsx</strong><dd><code>Support private task filter updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/TaskFilterModal/TaskFilterModal.tsx

<li>Introduced <code>handleFilterUpdate</code> interface and prop<br> <li> Updated <code>secondaryBtnAction</code> to pass args<br> <li> Implemented handler to bypass modal for private filters


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/636/files#diff-7b2f38a177a38ecf4cc731075b1dabaff389eb6498bf7a711a07e372415fb9a0">+11/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TaskFilterModalBody.tsx</strong><dd><code>Conditional private task update flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/TaskFilterModal/TaskFilterModalBody.tsx

<li>Detect <code>isPrivate</code> in <code>handleUpdateModalClick</code><br> <li> Call <code>handleFilterUpdate</code> with payload when private<br> <li> Retain dispatch logic for non-private updates


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/636/files#diff-3314b3e845291ca19567f2550cdf7db70dc626d5d36f5976ee21829feecdc69b">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Notes.tsx</strong><dd><code>Add null checks in RenderOwnerShipNotes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/AttributeFilterModal/Notes.tsx

<li>Guard <code>attributeFilter</code> existence before checks<br> <li> Wrap ownership note conditions under null-check<br> <li> Preserve original note rendering logic


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/636/files#diff-0468eeb43476581104d179b50512950bc451ae121a0e97f62567fa41b730cec1">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>