### PR TITLE
Fixed modal height

### DIFF
--- a/forms-flow-components/src/components/CustomComponents/BpmnDiagramView.tsx
+++ b/forms-flow-components/src/components/CustomComponents/BpmnDiagramView.tsx
@@ -12,10 +12,11 @@ interface ProcessDiagramProps {
   diagramXML: string;
   activityId: string;
   isProcessDiagramLoading: boolean;
+  showDiagramTools?:boolean;
 }
 
 const ProcessDiagram: React.FC<ProcessDiagramProps> = React.memo(
-  ({ diagramXML, activityId, isProcessDiagramLoading }) => {
+  ({ diagramXML, activityId, isProcessDiagramLoading, showDiagramTools=false }) => {
     const { t } = useTranslation();
     const [bpmnViewer, setBpmnViewer] = useState<any>(null);
 
@@ -104,7 +105,7 @@ const ProcessDiagram: React.FC<ProcessDiagramProps> = React.memo(
             ref={containerRef}
           />
         </div>
-        <div className="d-flex justify-content-end">
+       {showDiagramTools && <div className="d-flex justify-content-end">
           <div className="d-flex flex-column">
             <button className="mb-3" title="Reset Zoom" onClick={zoomReset}>
               <i className="fa fa-retweet" aria-hidden="true" />
@@ -116,7 +117,7 @@ const ProcessDiagram: React.FC<ProcessDiagramProps> = React.memo(
               <i className="fa fa-search-minus" aria-hidden="true" />
             </button>
           </div>
-        </div>
+        </div>}
       </>
     );
   }

--- a/forms-flow-components/src/components/CustomComponents/SubmissionHistoryWithViewButton.tsx
+++ b/forms-flow-components/src/components/CustomComponents/SubmissionHistoryWithViewButton.tsx
@@ -15,6 +15,7 @@ interface SubmissionHistoryWithViewButtonProps {
   activityId: string;
   isProcessDiagramLoading: boolean;
   isHistoryListLoading: boolean;
+  showDiagramTools?:boolean;
 }
 
 interface SubmissionHistory {
@@ -38,6 +39,7 @@ export const SubmissionHistoryWithViewButton: React.FC<SubmissionHistoryWithView
       activityId,
       isProcessDiagramLoading,
       isHistoryListLoading,
+      showDiagramTools = false
     }) => {
       const { t } = useTranslation();
       const timelineRef = useRef<HTMLDivElement>(null);
@@ -51,10 +53,6 @@ export const SubmissionHistoryWithViewButton: React.FC<SubmissionHistoryWithView
           if (timelineRef.current && historyContentRef.current) {
             const contentHeight = historyContentRef.current.offsetHeight;
             timelineRef.current.style.height = `${contentHeight}px`;
-            const bpmnContainer: HTMLElement = document.querySelector(".bpmn-viewer-container");
-            if (bpmnContainer) {
-              bpmnContainer.style.minHeight = `${contentHeight}px`;
-            }
           }
         };
      
@@ -120,13 +118,14 @@ export const SubmissionHistoryWithViewButton: React.FC<SubmissionHistoryWithView
          
                 <div
                   className={`${
-                    showBpmnDiagram && "d-flex justify-content-between gap-3 flex-column flex-lg-row "}`}
+                    showBpmnDiagram && "d-flex justify-content-between gap-3 flex-column flex-lg-row analyse-submision-history-modal"}`}
                 >
                   {showBpmnDiagram && (
                     <div className="p-5">
                       <ProcessDiagram
                         diagramXML={diagramXML ?? ""}
                         activityId={activityId ?? ""}
+                        showDiagramTools={showDiagramTools}
                         isProcessDiagramLoading={isProcessDiagramLoading}
                       />
                     </div>

--- a/forms-flow-theme/scss/bpmn.scss
+++ b/forms-flow-theme/scss/bpmn.scss
@@ -11,6 +11,8 @@ $gray-darkest: var(--ff-gray-darkest);
   position:relative; 
   min-height: 45vh; 
   min-width: 60vw; 
+  width: 100%;
+  height: 100%;
 }
 
  .grab-cursor {

--- a/forms-flow-theme/scss/historyModal.scss
+++ b/forms-flow-theme/scss/historyModal.scss
@@ -109,3 +109,6 @@ $white-color: var(--ff-white);
   }
 }
 
+.analyze-submision-history-modal{
+  min-height: 80vh;
+}


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE

# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add toggle for BPMN diagram tools

- Conditionally render zoom controls

- Remove manual JS height adjustment

- Update CSS for modal height


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BpmnDiagramView.tsx</strong><dd><code>Conditional display of diagram tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-components/src/components/CustomComponents/BpmnDiagramView.tsx

<li>Added optional <code>showDiagramTools</code> prop<br> <li> Defaulted <code>showDiagramTools</code> to false<br> <li> Wrapped zoom controls in conditional block


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/638/files#diff-901b4225f5f6cd510932769abdfb3f76f683d8bc18e9bdeee147adecf9f495d5">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SubmissionHistoryWithViewButton.tsx</strong><dd><code>Enable diagram tools and refine modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-components/src/components/CustomComponents/SubmissionHistoryWithViewButton.tsx

<li>Added <code>showDiagramTools</code> prop and default<br> <li> Removed manual BPMN container height script<br> <li> Passed <code>showDiagramTools</code> to ProcessDiagram<br> <li> Applied <code>analyse-submision-history-modal</code> CSS class


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/638/files#diff-977dc94a9ac9d3d2cabea092702fe1dbcc54019c483efff22edc9ff5ea00fe5e">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>historyModal.scss</strong><dd><code>Add modal height CSS class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-theme/scss/historyModal.scss

<li>Added <code>.analyze-submision-history-modal</code> class<br> <li> Set min-height to 80vh


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/638/files#diff-21e03e368c486012a595293d019220b38aa0a7f354a0c5a7d36189db53dc956a">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bpmn.scss</strong><dd><code>Size adjustments for BPMN container</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-theme/scss/bpmn.scss

<li>Set <code>.bpmn-viewer-container</code> width and height to 100%<br> <li> Added file end newline


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/638/files#diff-c5e853772f4cbf5e4fa68827713232d5f56d662b3853de60531985f4a618b511">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>