### PR TITLE
[BugFix]: Filter ownership note bug fixed

### DIFF
--- a/forms-flow-review/src/components/AttributeFilterModal/AttributeFIlterModalBody.tsx
+++ b/forms-flow-review/src/components/AttributeFilterModal/AttributeFIlterModalBody.tsx
@@ -442,7 +442,6 @@ const saveButtonVariant = saveSuccess.showSuccess ? "success" : "secondary";
 
     if (createFilters ) {
       return (
-        <div className="pt-4">
           <CustomButton
   variant={saveButtonVariant}
   size="md"
@@ -458,7 +457,7 @@ const saveButtonVariant = saveSuccess.showSuccess ? "success" : "secondary";
   disabled={isUnsavedFilter || filterNameError || noFieldChanged || !filterName}
 />
 
-        </div>
+
       );
     }
 

--- a/forms-flow-review/src/components/AttributeFilterModal/Notes.tsx
+++ b/forms-flow-review/src/components/AttributeFilterModal/Notes.tsx
@@ -39,7 +39,7 @@ const RenderOwnerShipNotes = ({isCreator, attributeFilter}) => {
   }
 
   
-if(attributeFilter){
+if(attributeFilter?.id){
 if (!isCreator) {
     return (
       <div className="pb-4">

--- a/forms-flow-review/src/components/TaskFilterModal/SaveFilterTab.tsx
+++ b/forms-flow-review/src/components/TaskFilterModal/SaveFilterTab.tsx
@@ -124,7 +124,7 @@ const SaveFilterTab = ({
       );
     }
 
-    if (!editRole) {
+    if (!editRole && filterToEdit.id) {
       return (
         <CustomInfo
           className="note"
@@ -140,7 +140,8 @@ const SaveFilterTab = ({
     if (manageAllFilters && !createdByMe) {
       return (
         <>
-          <div className="pb-4">
+        {filterToEdit.id && (
+           <div className="pb-4">
             <CustomInfo
               className="note"
               heading="Note"
@@ -153,6 +154,8 @@ const SaveFilterTab = ({
               dataTestId="task-filter-save-note"
             />
           </div>
+        )}
+         
           <CustomInfo
             className="note"
             heading="Note"


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE

# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->


___

### **PR Type**
Bug fix


___

### **Description**
- Removed extra padding wrapper div around save button

- Required `attributeFilter.id` before rendering ownership notes

- Required `filterToEdit.id` before showing save filter notes


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Remove wrapper div in AttributeFilterModalBody"] --> B["Require id in Notes.tsx"]
  B --> C["Require filterToEdit.id in SaveFilterTab"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AttributeFIlterModalBody.tsx</strong><dd><code>Remove wrapper div around save button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/AttributeFilterModal/AttributeFIlterModalBody.tsx

<li>Removed <code><div className="pt-4"></code> wrapper around save button<br> <li> Adjusted indentation for <code>CustomButton</code> rendering


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/660/files#diff-b021bf706f401cb6d9da5f2772eaa356cb1ad49ba57e4a01b0969ead7c1f4afa">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Notes.tsx</strong><dd><code>Require filter ID for ownership notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/AttributeFilterModal/Notes.tsx

<li>Changed <code>if(attributeFilter)</code> to <code>if(attributeFilter?.id)</code><br> <li> Ensures ownership notes only show for saved filters


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/660/files#diff-0468eeb43476581104d179b50512950bc451ae121a0e97f62567fa41b730cec1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SaveFilterTab.tsx</strong><dd><code>Require filter ID in save filter notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/TaskFilterModal/SaveFilterTab.tsx

<li>Added <code>filterToEdit.id</code> check in <code>!editRole</code> condition<br> <li> Wrapped manageAllFilters note div with <code>filterToEdit.id</code> check


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/660/files#diff-6fb0e7047ea4a548b95133535a89a06af59cffcc2b787d8813d9230bbf3904fd">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>