### PR TITLE
FWF-4906 [fixed] prevent task fetch  multiple api call trigger, and multiple info call , added signel into request httpPOSTRequestWithHAL

### DIFF
--- a/forms-flow-review/src/index.tsx
+++ b/forms-flow-review/src/index.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useMemo, useState } from "react";
+import React, {useCallback, useEffect, useMemo, useState } from "react";
 import { Route, Switch, Redirect, useParams,useHistory } from "react-router-dom";
 import { KeycloakService, StorageService } from "@formsflow/service";
 import {
@@ -133,26 +133,26 @@ const handleForceReload = (refreshedTaskId: string) => {
   }
 };
 
-const SocketIOCallback = ({
-  refreshedTaskId,
-  forceReload,
-  isUpdateEvent,
-}: SocketUpdateParams) => {
-  if (!refreshedTaskId) return;
-   /**
-     * use of this socket call back , need to update task realtime and 
-     * also tasklist if the task id is exist inthe tasklist
-     */
-  if (isUpdateEvent) { 
-    handleTaskUpdate(refreshedTaskId);
-  } else if (forceReload) {
-    handleForceReload(refreshedTaskId);
-  }else{
-    // here we just need to refetch the task list
-    // this is used when task is created or deleted
-    getTasks();
-  }
-};
+const SocketIOCallback = useCallback(({
+    refreshedTaskId,
+    forceReload,
+    isUpdateEvent,
+  }: SocketUpdateParams) => {
+    if (!refreshedTaskId) return;
+    /**
+       * use of this socket call back , need to update task realtime and 
+       * also tasklist if the task id is exist inthe tasklist
+       */
+    if (isUpdateEvent) { 
+      handleTaskUpdate(refreshedTaskId);
+    } else if (forceReload) {
+      handleForceReload(refreshedTaskId);
+    }else{
+      // here we just need to refetch the task list
+      // this is used when task is created or deleted
+      getTasks();
+    }
+  },[taskId, taskDetails, lastRequestedPayload, activePage, limit]);
 
  
 

--- a/forms-flow-service/src/request/requestService.ts
+++ b/forms-flow-service/src/request/requestService.ts
@@ -179,7 +179,8 @@ class RequestService {
     url: string,
     data: object,
     token: string | null,
-    isBearer: boolean = true
+    isBearer: boolean = true,
+    signal?: AbortSignal 
   ): any {
     return this.axiosInstance.post(url, data, {
       headers: {
@@ -190,6 +191,7 @@ class RequestService {
           : token,
         Accept: "application/hal+json",
       },
+      signal
     });
   }
   public static httpPUTRequest(


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA:  https://aottech.atlassian.net/browse/FWF-4906
Issue Type: BUG 
# Changes
Added signal to abort redundant api calls
removed redundant code
used useCallbak to prevent recreate the socket io call bak


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Abort redundant task fetch calls with AbortController

- Pass abort `signal` into HTTP POST requests

- Memoize SocketIO callback using `useCallback`


___

### **Changes diagram**

```mermaid
flowchart LR
  FS["fetchServiceTaskList"] -- "abort previous call" --> AC["AbortController"]
  AC -- "provide signal" --> HTTP["RequestService.httpPOSTRequestWithHAL"]
  SI["SocketIOCallback"] -- "wrapped by useCallback" --> UC["useCallback hook"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>filterServices.ts</strong><dd><code>Add abort controller to prevent redundant requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/api/services/filterServices.ts

<li>Declare <code>currentTaskFetchAbortController</code> variable<br> <li> Abort existing fetch when new fetch starts<br> <li> Initialize new AbortController and extract <code>signal</code><br> <li> Pass <code>signal</code> into <code>httpPOSTRequestWithHAL</code>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/677/files#diff-77fbf5e8f8c863ff6549b8ed61329caf3e8ae748f61a09585be53ecddecf4ad1">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Memoize SocketIO callback with useCallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/index.tsx

<li>Import <code>useCallback</code> from React<br> <li> Wrap <code>SocketIOCallback</code> in <code>useCallback</code> hook<br> <li> Add dependency array <code>[taskId, taskDetails, lastRequestedPayload, </code><br><code>activePage, limit]</code>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/677/files#diff-d9e4f89db1480f2ddf9a95d909181b7d10b5ea4e7e7da5e4af8c299545220193">+21/-21</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>requestService.ts</strong><dd><code>Support abort signal in HTTP POST requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-service/src/request/requestService.ts

<li>Extend <code>httpPOSTRequestWithHAL</code> signature with optional <code>signal</code><br> <li> Inject <code>signal</code> into axios request config


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/677/files#diff-b89b23a9a01f4f37d58c84eb0e377d1e4dceef29969678768672f4db71856f3b">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>