### PR TITLE
task variables issue fix

### DIFF
--- a/forms-flow-review/src/components/TaskFilterModal/TaskFilterModalBody.tsx
+++ b/forms-flow-review/src/components/TaskFilterModal/TaskFilterModalBody.tsx
@@ -346,36 +346,7 @@ const transformToDynamicVariables = (taskVariables, existingVars) => {
     );
 };
 
-const processEditingMode = (taskVariables, filterToEdit, defaultTaskVariable) => {
-  const existingFormVariables = filterToEdit?.variables?.filter(v => v.isFormVariable) || [];
-  
-  const newDynamicVariables = taskVariables
-    .filter(taskVar => 
-      isValidVariableType(taskVar) && 
-      !isDuplicateVariable(taskVar, defaultTaskVariable)
-    )
-    .map((variable, index) => {
-      const existingVar = findExistingVariable(existingFormVariables, variable);
-      
-      return createVariableFromTask(
-        variable,
-        existingVar ? existingVar.sortOrder - 1 : defaultTaskVariable.length + existingFormVariables.length + index,
-        existingVar ? existingVar.isChecked : false
-      );
-    });
 
-  // Merge default variables with existing values from filter
-  const defaultVars = defaultTaskVariable.map(defaultVar => {
-    const existingVar = findExistingVariable(filterToEdit?.variables || [], defaultVar);
-    return existingVar || defaultVar;
-  });
-
-  // Combine and deduplicate form variables
-  const allFormVariables = [...existingFormVariables, ...newDynamicVariables];
-  const uniqueFormVariables = removeDuplicateVariables(allFormVariables);
-
-  return [...defaultVars, ...uniqueFormVariables];
-};
 
 const processNewFilterMode = (taskVariables, defaultTaskVariable) => {
   const dynamicVariables = transformToDynamicVariables(taskVariables, defaultTaskVariable);


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-4869
# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Streamline task variable fetch and transform logic

- Add validation and deduplication helper functions

- Merge and preserve existing variables when editing

- Trigger variable fetch on form selection


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TaskFilterModalBody.tsx</strong><dd><code>Enhance task variable management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/TaskFilterModal/TaskFilterModalBody.tsx

<li>Introduced <code>isValidVariableType</code>, <code>createVariableFromTask</code>, helpers<br> <li> Refactored <code>transformToDynamicVariables</code> and removed duplicates<br> <li> Enhanced <code>handleFetchTaskVariables</code> to merge edit-mode variables<br> <li> Added fetch trigger on form selection via <code>handleFetchTaskVariables</code>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/678/files#diff-3314b3e845291ca19567f2550cdf7db70dc626d5d36f5976ee21829feecdc69b">+101/-33</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>