### PR TITLE
FWF-4973: [BugFix] hide filter with same name issue fixed

### DIFF
--- a/forms-flow-components/src/components/CustomComponents/DragandDropSort.tsx
+++ b/forms-flow-components/src/components/CustomComponents/DragandDropSort.tsx
@@ -3,12 +3,12 @@ import { DraggableIcon, CheckboxCheckedIcon, CheckboxUncheckedIcon } from "../Sv
 import Sortable from "sortablejs";
 
 interface FilterItem {
+  id:  number;
   label?: string;
   name: string;
   isChecked?: boolean;
   sortOrder?: number;
   isFormVariable?: boolean;
-  itemId?: number;
   icon?: React.ReactNode;
 }
 
@@ -112,20 +112,20 @@ useEffect(() => {
     <div className="drag-drop-container list-action rearrangable checkbox" ref={containerRef}>
       <ul  ref={listRef}>
         {filterItems.map((item, index) => (
-          <li
-            key={item.itemId ?? `${item.name}-${index}`}
+          <li key={item.id ?? `${item.name}-${index}`}
             className="draggable-item"
           >
+
             <button
               className="draggable-icon"
-              draggable 
+              draggable
             >
               <DraggableIcon />
             </button>
 
-            <label htmlFor={`${item.name}-checkbox-id`} className="input-checkbox">
+            <label htmlFor={`${item.id ?? item.name}-checkbox-id`} className="input-checkbox">
               <input
-                id={`${item.name}-checkbox-id`}
+                id={`${item.id ?? item.name}-checkbox-id`}
                 type="checkbox"
                 checked={item.isChecked}
                 onChange={() => onCheckboxChange(index)}


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-4973
Issue Type: BUG/ FEATURE

# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->


___

### **PR Type**
Bug fix


___

### **Description**
- Use `id` instead of `itemId` for unique keys

- Update JSX `key` and `input` IDs using `id`

- Remove deprecated `itemId` property

- Clean up `draggable` attribute formatting


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DragandDropSort.tsx</strong><dd><code>Use id for list item keys and IDs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-components/src/components/CustomComponents/DragandDropSort.tsx

<ul><li>Added <code>id: number</code> to <code>FilterItem</code> interface<br> <li> Removed deprecated <code>itemId</code> property<br> <li> Updated <code><li key></code> and <code>label/htmlFor</code> to use <code>item.id</code><br> <li> Cleaned up <code>draggable</code> attribute whitespace</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/697/files#diff-0f3c3e7185d3cf74e4aa25331b77e5d34bff0465480b510a39bf0ad6d2f20572">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

