### PR TITLE
FWF- 5135 [Bugfix] Task count with 0 not resetting the task list issue fixed and added a test useeffect to test socket response on assignee change from task details page

### DIFF
--- a/forms-flow-review/src/Routes/TaskDetails.tsx
+++ b/forms-flow-review/src/Routes/TaskDetails.tsx
@@ -162,6 +162,11 @@ const TaskDetails = () => {
     dispatch,
   ]);
 
+  //test to see task assignee data is captured
+  useEffect(() => {
+    console.log("task test",task);
+  }, [task]);
+
   // Form submission callback
   const onFormSubmitCallback = (actionType = "") => {
     if (!bpmTaskId || !task?.formUrl) return;

--- a/forms-flow-review/src/api/services/filterServices.ts
+++ b/forms-flow-review/src/api/services/filterServices.ts
@@ -41,10 +41,13 @@ export const getUserRoles = () => {
 };
 
 const handleTaskError = (dispatch, error) => {
-  // dispatch(setBPMTaskList([]));
-  dispatch(setBPMTaskCount(0));
   dispatch(serviceActionError(error));
 };
+
+const clearTableData = (dispatch) => {
+  dispatch(setBPMTaskList([]));
+  dispatch(setBPMTaskCount(0));
+}
 
 /**
  * Fetches the task list from the server and updates the redux store with the task list and count.
@@ -120,7 +123,9 @@ export const fetchServiceTaskList = (
           const _embedded = responseData[0]?._embedded; // data._embedded.task is where the task list is.
           if (!_embedded?.task || !responseData?.[0]?.count) {
             // Display error if the necessary values are unavailable.
-            handleTaskError(dispatch, res);
+            // handleTaskError(dispatch, res);
+            // Clear table data if the response has count as 0 or if response has empty tasks
+            clearTableData(dispatch);
           } else {
             const taskListFromResponse = _embedded["task"]; // Gets the task array
             const taskCount = {
@@ -144,7 +149,7 @@ export const fetchServiceTaskList = (
             done(null, taskData);
           }
         } else {
-          handleTaskError(dispatch, res);
+          clearTableData(dispatch);
         }
       })
       .catch((error) => {

--- a/forms-flow-review/src/components/TaskFilterModal/TaskFilterModal.tsx
+++ b/forms-flow-review/src/components/TaskFilterModal/TaskFilterModal.tsx
@@ -68,7 +68,7 @@ const TaskFilterModal = ({ show, onClose, toggleModal }) => {
   const handleBatchFunctionWhenThereIsNoFilter = () => {
     dispatch(setDefaultFilter(null));
     dispatch(setSelectedFilter(null));
-    // dispatch(setBPMTaskList([]));
+    dispatch(setBPMTaskList([]));
     dispatch(setBPMFiltersAndCount([]));
   };
 


### PR DESCRIPTION
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-5135
Issue Type: BUG

# Changes
- Issue when task-filter api returning count as 0 and table not refreshing issue fixed by reverting code of [] setting when count is 0
- Added a test useeffect to check whether task details (assignee) is resetting in details page if socket is triggered on update event , when assignee of current task is changed. 
