### PR TITLE
FWF-5138 : [BugFix] filter persist issue fixe, active filter fix

### DIFF
--- a/forms-flow-submissions/src/Routes/SubmissionListing.tsx
+++ b/forms-flow-submissions/src/Routes/SubmissionListing.tsx
@@ -135,6 +135,8 @@ useEffect(() => {
   const filter = matched ?? null; 
 
   dispatch(setSelectedSubmisionFilter(filter));
+  dispatch(setDefaultSubmissionFilter(filter?.id));
+  updateDefaultSubmissionFilter({ defaultSubmissionsFilter: filter?.id });
   setSubmissionFields(filter?.variables ?? DEFAULT_SUBMISSION_FIELDS);
 }, [dropdownSelection, filterList]);
 
@@ -609,7 +611,7 @@ const renderRow = (submission: Submission) => {
       <div className="left-panel">
         <CollapsibleSearch
           isOpen={true}
-          hasActiveFilters={Object.keys(searchFieldValues).length > 0 }
+          hasActiveFilters={Object.keys(searchFieldValues).length > 0 || dropdownSelection !== null}
           inactiveLabel="No Filters"
           activeLabel="Filters Active"
           onToggle={() => { }}


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-5138
Issue Type: BUG

# Changes
* Fixed : 
  * Selected form getting resetting to default on redirecting back to submissions from View details page
  * Collapse side bar is not active even though a filter is selected


___

### **PR Type**
Bug fix


___

### **Description**
- Persist default submission filter on selection

- Dispatch `setDefaultSubmissionFilter` and backend update

- Show active filter state when dropdown selected

- Update fields based on filter variables


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SubmissionListing.tsx</strong><dd><code>Persist default filter and active status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-submissions/src/Routes/SubmissionListing.tsx

<ul><li>Added <code>setDefaultSubmissionFilter</code> dispatch<br> <li> Sent <code>updateDefaultSubmissionFilter</code> API call<br> <li> Extended <code>hasActiveFilters</code> logic with dropdown check</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/741/files#diff-1e75247435a3a424e8e37d4217fab202a48aa06804a6c1188407b0a34f27d909">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

