### PR TITLE
bugfix/fwf-5139:Fixed styles issues in variables selection modal

### DIFF
--- a/forms-flow-components/src/components/CustomComponents/FormComponent.tsx
+++ b/forms-flow-components/src/components/CustomComponents/FormComponent.tsx
@@ -104,6 +104,7 @@ export const FormComponent: React.FC<FormComponentProps> = React.memo(
       "container",
       "htmlelement",
       "tabs",
+      "survey"
     ]);
     const ignoredKeys = new Set(["hidden"]);
 

--- a/forms-flow-submissions/src/index.scss
+++ b/forms-flow-submissions/src/index.scss
@@ -14,8 +14,16 @@ top: 0;
 bottom: 0;
 }
 
-.page-item .page-link {
-    color: var(--ff-primary) !important;
+.page-item 
+{
+    &.active{
+        .page-link{
+            color:var(--ff-white) !important;
+        }
+    }
+    .page-link {
+        color: var(--ff-primary) !important;
+    }
 }
 
 .premium{

--- a/forms-flow-theme/scss/external/formio.scss
+++ b/forms-flow-theme/scss/external/formio.scss
@@ -84,6 +84,7 @@ $gray-dark: var(--ff-gray-dark);
       '.formio-component-tabs',
       '.formio-component-submit',
       '.formio-component-hidden',
+      '.formio-component-survey', 
     );
   
     .variable-modal {


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-5139
Issue Type: BUG

# Changes
1. Prevented selection of survey component in variable modal 
2. fixed wizard form tab style issue  
## screenshots 

<img width="1801" height="812" alt="image" src="https://github.com/user-attachments/assets/3782ace4-39b5-4bbe-8c14-506baf640b6d" />


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent survey type selection in variable modal

- Add survey CSS class to ignore list

- Refactor pagination .page-item styles


___

### Diagram Walkthrough


```mermaid
flowchart LR
  FC["FormComponent.tsx"]
  TF["formio.scss"]
  IN["index.scss"]
  MOD["Variable Selection Modal"]
  PAG["Pagination UI"]
  FC -- "ignore survey type" --> MOD
  TF -- "add .formio-component-survey class" --> MOD
  IN -- "update page-link colors" --> PAG
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FormComponent.tsx</strong><dd><code>Add survey to ignoredTypes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-components/src/components/CustomComponents/FormComponent.tsx

<ul><li>Added "survey" to <code>ignoredTypes</code> set<br> <li> Prevents survey component selection in modal</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/742/files#diff-153b3c47f9db406688015d8ac74e4fa312c1e58caa13546ea3de41f1c9b03ee0">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.scss</strong><dd><code>Refactor pagination link styles</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-submissions/src/index.scss

<ul><li>Refactored <code>.page-item</code> with nested styles<br> <li> Set active <code>.page-link</code> color to white<br> <li> Retained default primary link color</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/742/files#diff-873b32fa83d75d1d8841b3d7675f3e9ee2c49f2124e305abbdc694e1a0299bf1">+10/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>formio.scss</strong><dd><code>Hide survey component in modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-theme/scss/external/formio.scss

<ul><li>Added <code>.formio-component-survey</code> to ignore list<br> <li> Ensures survey component hidden in modal</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/742/files#diff-846bbc19d9550d7651de678f2245e8c771e308eed0a52730ab50f5bbed8b9744">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

