### PR TITLE
FWF-5138 : [BugFix] Fixed search issue with another page

### DIFF
--- a/forms-flow-submissions/src/Routes/SubmissionListing.tsx
+++ b/forms-flow-submissions/src/Routes/SubmissionListing.tsx
@@ -110,6 +110,7 @@ const AnalyzeSubmissionList: React.FC = () => {
 
   // Wrapper function to reset lastFetchedFormId when dropdown selection changes
   const handleDropdownSelectionChange = useCallback((newSelection: string | null) => {
+    dispatch(setAnalyzeSubmissionPage(1)); 
     if (newSelection !== dropdownSelection) {
       setLastFetchedFormId(null); // Reset the cached form ID when selection changes
     }
@@ -182,7 +183,6 @@ const handleFieldSearch = (filters: Record<string, string>) => {
   dispatch(setAnalyzeSubmissionPage(1)); 
   setFiltersApplied(true);
   dispatch(setSearchFieldValues(filters));
-  refetch(); 
 };
  
 

--- a/forms-flow-submissions/src/Routes/SubmissionListing.tsx
+++ b/forms-flow-submissions/src/Routes/SubmissionListing.tsx
@@ -179,9 +179,10 @@ useEffect (() => {
   
 const handleFieldSearch = (filters: Record<string, string>) => {
   setFieldFilters(filters);
+  dispatch(setAnalyzeSubmissionPage(1)); 
   setFiltersApplied(true);
   dispatch(setSearchFieldValues(filters));
-
+  refetch(); 
 };
  
 


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-5138
Issue Type: BUG

# Changes
* Fixed search not found while in another page issue


___

### **PR Type**
Bug fix


___

### **Description**
- Reset pagination on dropdown change

- Reset pagination on field search

- Dispatch page index reset action


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SubmissionListing.tsx</strong><dd><code>Reset analyze page index on filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-submissions/src/Routes/SubmissionListing.tsx

<ul><li>Added dispatch to reset page on dropdown change<br> <li> Added dispatch to reset page on field search</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/743/files#diff-1e75247435a3a424e8e37d4217fab202a48aa06804a6c1188407b0a34f27d909">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

