### PR TITLE
FWF-4988:[Feature] - Custom header adjustment for vizard forms

### DIFF
--- a/forms-flow-theme/scss/_forms.scss
+++ b/forms-flow-theme/scss/_forms.scss
@@ -718,7 +718,6 @@ select option:hover {
 .userform-wrapper{
   display: flex;
   flex-direction: column;
-  gap: var(--spacer-200);
   background-color: $gray-light;
 
   .user-form-header{
@@ -750,8 +749,8 @@ select option:hover {
     color: $white;
   }
  }
+  .user-form-container-with-wizard,
   .user-form-container{
-    height: calc(100vh - 7.5625rem - var(--client-nav));
     overflow-y: auto;
     overflow-x: hidden;
     gap: var(--spacer-100);
@@ -760,6 +759,13 @@ select option:hover {
     border-radius: var(--radius-md)!important;
     min-width: 75vw;
   }
+  .user-form-container {
+    height: calc(100vh - 7.5625rem - var(--client-nav));
+  }
+  .user-form-container-with-wizard {
+    height: calc(100vh - 8.5625rem - var(--client-nav));
+  }
+
 }
 
 //custom switch for sdpr


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-4988
Issue Type: BUG/ FEATURE

# Changesu
Fixed Header visibility issue in anonymous form

#Screenshot
<img width="2940" height="1592" alt="image" src="https://github.com/user-attachments/assets/db658050-0509-40d8-8282-a10d0589a435" />


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Separate heights for wizard vs normal form containers

- Increase wizard container height by 1rem

- Remove gap in `.userform-wrapper`

- Minor SCSS cleanup and refactoring


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[".user-form-container"] --> B["height: calc(100vh - 7.5625rem - var(--client-nav))"]
  C[".user-form-container-with-wizard"] --> D["height: calc(100vh - 8.5625rem - var(--client-nav))"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_forms.scss</strong><dd><code>Refactor form container heights and spacing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-theme/scss/_forms.scss

<ul><li>Removed <code>gap: var(--spacer-200)</code> from <code>.userform-wrapper</code><br> <li> Extracted and removed shared height from merged container selectors<br> <li> Added distinct height rules for wizard and non-wizard containers<br> <li> Adjusted wizard container height to account for extra header space</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/744/files#diff-4cb04448c2a9512ee4ab5e5a6d5802c5360501e0874846848e2bbd0bfc6338e8">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

