### PR TITLE
FWF-5325:[Feature] - Task Loading issue solved.

### DIFF
--- a/forms-flow-review/src/api/services/bpmTaskServices.ts
+++ b/forms-flow-review/src/api/services/bpmTaskServices.ts
@@ -43,8 +43,8 @@ export const getBPMTaskDetail = (taskId, ...rest) => {
           const variablesDetails = responses[1]?.data;
           if (taskDetails) {
             if (variablesDetails) {
-              let formId = variablesDetails?.formId.value;
-              let formType = variablesDetails?.formType.value;
+              let formId = variablesDetails?.formId?.value;
+              let formType = variablesDetails?.formType?.value;
               taskDetails = {
                 ...taskDetailVariableDataFormatter(variablesDetails),
                 ...taskDetails,

--- a/forms-flow-review/src/components/FormSelectionModal.tsx
+++ b/forms-flow-review/src/components/FormSelectionModal.tsx
@@ -33,7 +33,7 @@ export const FormSelectionModal: React.FC<FormSelectionModalProps> = React.memo(
       if (forms.length) {
         setFormNames({
           data: forms
-            .filter((i) => i.formType === "form") 
+            .filter((i) => !i?.formType || i.formType === "form")
             .map((i) => ({
               formName: i.formName,
               formId: i.formId,
@@ -64,14 +64,18 @@ export const FormSelectionModal: React.FC<FormSelectionModalProps> = React.memo(
         );
       } else {
         // no search term → show all items with formType = "form"
-        setFilteredFormNames(formNames?.data.filter((i) => i.formType === "form"));
+        setFilteredFormNames(
+          formNames?.data?.filter((i) => !i?.formType || i.formType === "form") || []
+        );        
       }
     
       setLoadingForm(false);
     };
     const handleClearSearch = () => {
       setSearchFormName("");
-      setFilteredFormNames(formNames?.data.filter((i) => i.formType === "form"));
+      setFilteredFormNames(
+        formNames?.data?.filter((i) => !i?.formType || i.formType === "form") || []
+      );      
     };
     const getFormOptions = () => {
       return searchFormName ? filteredFormNames : formNames.data;


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-5325
Issue Type: BUG/ FEATURE

# Changes

Updated the code where checking the form type.
the form type key was missing in Open source but present in EE. 
updated the logic with  OS response compatibility 

#Screenshots:
https://jam.dev/c/3b244806-213b-445f-b2c0-6f4e547d95fc


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Handle missing formType safely

- Add optional chaining for variables payload

- Broaden form filtering for OS data

- Improve null-safe filtering defaults


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BPM task variables parsing"] -- "optional chaining for values" --> B["Safe formId/formType extraction"]
  C["Form list building"] -- "allow missing formType" --> D["Filter forms: !formType or 'form'"]
  E["Search/clear handlers"] -- "null-safe defaults" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>bpmTaskServices.ts</strong><dd><code>Safely extract task form variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/api/services/bpmTaskServices.ts

<ul><li>Use optional chaining for <code>formId</code> and <code>formType</code>.<br> <li> Prevent runtime errors on missing variable fields.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/789/files#diff-caf35f161a4052dc59c9e528ca54dbef8460cfdc412a981668c57bd2afefce69">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FormSelectionModal.tsx</strong><dd><code>Robust form filtering for absent formType</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/FormSelectionModal.tsx

<ul><li>Include items with missing <code>formType</code> in filters.<br> <li> Apply null-safe chaining on <code>formNames?.data</code>.<br> <li> Provide empty-array fallback for filtered results.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/789/files#diff-4e50baae92e91088d286613988a030ed0637d749e908f7a35f521d5d6450a7c1">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

