### PR TITLE
FWF-5333 [update] style fix for form import

### DIFF
--- a/forms-flow-theme/scss/fileUpload.scss
+++ b/forms-flow-theme/scss/fileUpload.scss
@@ -84,15 +84,12 @@ $font-size-xs: var(--font-size-xs);
 }
 
 .upload-form-details {
-  overflow-wrap: break-word;
-  word-wrap: break-word;
-  word-break: break-word;
-  max-width: 100%;
+  overflow: hidden;
   color: var(--ff-black);
+  text-overflow: ellipsis;
   font-size: $font-size-xs;
   font-weight: var(--font-weight-sm);
   line-height: var(--text-line-height);
-  white-space: normal;
 }
 
 .import-error-note {

--- a/forms-flow-theme/scss/fileUpload.scss
+++ b/forms-flow-theme/scss/fileUpload.scss
@@ -60,6 +60,10 @@ $font-size-xs: var(--font-size-xs);
   align-items: center;
   gap: var(--spacer-150);
   align-self: stretch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
 }
 
 .upload-body {
@@ -80,12 +84,15 @@ $font-size-xs: var(--font-size-xs);
 }
 
 .upload-form-details {
-  overflow: hidden;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-word;
+  max-width: 100%;
   color: var(--ff-black);
-  text-overflow: ellipsis;
   font-size: $font-size-xs;
   font-weight: var(--font-weight-sm);
   line-height: var(--text-line-height);
+  white-space: normal;
 }
 
 .import-error-note {


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-5333
<img width="1123" height="554" alt="image" src="https://github.com/user-attachments/assets/1e3bb9a2-f682-4713-9a4b-7cf5299015c9" />

# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->


___

### **PR Type**
Enhancement


___

### **Description**
- Truncate long upload file names

- Prevent overflow in file name container


___

### Diagram Walkthrough


```mermaid
flowchart LR
  SCSS["fileUpload.scss styles"] -- "add overflow handling" --> UploadName[".upload-file-name"]
  UploadName -- "ellipsis + nowrap" --> TruncatedDisplay["Truncated file name display"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fileUpload.scss</strong><dd><code>Handle long file names with ellipsis</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-theme/scss/fileUpload.scss

<ul><li>Add overflow hidden to <code>.upload-file-name</code><br> <li> Add text-overflow ellipsis for truncation<br> <li> Enforce nowrap to keep single line<br> <li> Set max-width to 100% for container</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/805/files#diff-0ad6c9c621b4cfba1d79f6feb0723caa2c620669e99558b34356c03346931327">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

