### PR TITLE
FWF-5366 [bugfix] updated logic of form variable selection

### DIFF
--- a/forms-flow-components/src/components/CustomComponents/FormComponent.tsx
+++ b/forms-flow-components/src/components/CustomComponents/FormComponent.tsx
@@ -9,15 +9,15 @@ interface SelectedComponent {
   altVariable: string;
   isFormVariable: boolean;
 }
+
 interface FormComponentProps {
   form: any;
   alternativeLabels: any;
   setSelectedComponent: (value: SelectedComponent) => void;
   setShowElement: (value: boolean) => void;
-  detailsRef: React.RefObject<HTMLInputElement> ;
+  detailsRef: React.RefObject<HTMLInputElement>;
   ignoreKeywords: Set<string>;
 }
-
 
 export const FormComponent: React.FC<FormComponentProps> = React.memo(
   ({
@@ -28,11 +28,9 @@ export const FormComponent: React.FC<FormComponentProps> = React.memo(
     detailsRef,
     ignoreKeywords
   }) => {
-
-
     const formRef = useRef(null);
+    const formHilighterRef = useRef<HTMLDivElement>(null); // Add ref for the form container
     
-     
     /* ------------- manipulate the hidden variable to show in form ------------- */
     const [updatedForm, setUpdatedForm] = useState(null);
     const [manipulatedKeys, setManipulatedKeys] = useState(new Set());
@@ -55,8 +53,7 @@ export const FormComponent: React.FC<FormComponentProps> = React.memo(
         ? [...getParentKeys(parentComponent.parentElement), nestedContainer]
         : getParentKeys(parentComponent.parentElement);
     }
-    // Filter out applicationId and applicationStatus
-    
+
     // initially we had a problem with the hidden variable not showing in the form so we have to manipulate the hidden variable to show in form
     useEffect(() => {
       const data = _.cloneDeep(form);
@@ -65,7 +62,6 @@ export const FormComponent: React.FC<FormComponentProps> = React.memo(
         data.components,
         (component) => {
           // remove display (show/hide) conditions for showing the component in taskvariable modal
-          /* --------------------------- ------------------ --------------------------- */
           component.conditional = {};
           component.customConditional = "";
           component.logic = [];
@@ -78,7 +74,7 @@ export const FormComponent: React.FC<FormComponentProps> = React.memo(
               [component.key]: component.type,
             }));
           }
-          /* ---------------------------------- ---- ---------------------------------- */
+
           //Keys ignored for the default task variable that don't need to be displayed in the form.
           if (
             component.type == "hidden" &&
@@ -95,7 +91,7 @@ export const FormComponent: React.FC<FormComponentProps> = React.memo(
       setManipulatedKeys(new Set(manipulatedKeys));
     }, [form, ignoreKeywords]);
 
-    //   These ignored keys and types from rendering the form.
+    // These ignored keys and types from rendering the form.
     const ignoredTypes = new Set([
       "button",
       "columns",
@@ -111,7 +107,7 @@ export const FormComponent: React.FC<FormComponentProps> = React.memo(
     ]);
     const ignoredKeys = new Set(["hidden"]);
 
-    //   This function is used to get the  keys and types  of the component.
+    // This function is used to get the keys and types of the component.
     const handleClick = useCallback(
       (e) => {
         const formioComponent = e.target.closest(".formio-component");
@@ -129,16 +125,14 @@ export const FormComponent: React.FC<FormComponentProps> = React.memo(
           );
           const keyClass = classes[classes.length - 1];
           const typeClass = classes[classes.length - 2];
-          //if key and type are same , then there will be only one class for both
           
-          const componentKey =(keyClass as string)?.split("-").pop();
+          const componentKey = (keyClass as string)?.split("-").pop();
           const componentType = typeClass
             ? (typeClass as string).split("-").pop()
-            :componentKey;
+            : componentKey;
 
           // Check if the component type is in the ignored list
           // Check if the component key is in the ignored list
-
           if (
             ignoredTypes.has(componentType) ||
             ignoredKeys.has(componentKey)
@@ -194,51 +188,55 @@ export const FormComponent: React.FC<FormComponentProps> = React.memo(
           });
         }
       },
-      [alternativeLabels, manipulatedKeys]
+      [alternativeLabels, manipulatedKeys, setShowElement, setSelectedComponent]
     );
 
-        // hide details when clicking outside form component and removinf the formio-highlighted class
+    // FIXED: Use ref instead of querySelector and add proper cleanup
     useEffect(() => {
-      const formHilighter = document.querySelector(".form-hilighter");
+      const formHilighter = formHilighterRef.current; // Use ref instead of querySelector
+      
+      if (!formHilighter) return; // Early return if element doesn't exist
 
       const handleOutsideClick = (event) => {
-        const clickedInsideForm = formHilighter?.contains(event.target);
+        const clickedInsideForm = formHilighter.contains(event.target);
         const clickedInsideDetails = detailsRef.current?.contains(event.target);
 
         if (!clickedInsideForm && !clickedInsideDetails) {
           setShowElement(false);
           const highlightedElement = document.querySelector(".formio-hilighted");
           if (highlightedElement) {
-            highlightedElement.classList.remove("formio-hilighted"); // Remove the highlight class
+            highlightedElement.classList.remove("formio-hilighted");
           }
         }
       };
-      formHilighter?.addEventListener("click", handleClick);
+
+      // Add event listeners
+      formHilighter.addEventListener("click", handleClick);
       document.addEventListener("mousedown", handleOutsideClick);
 
       return () => {
-        formHilighter?.removeEventListener("click", handleClick);
+        formHilighter.removeEventListener("click", handleClick);
         document.removeEventListener("mousedown", handleOutsideClick);
       };
-    }, [handleClick]);
+    }, [handleClick, setShowElement, detailsRef]);
 
-
-    
     return (
       <div className="flex">
-        <div className="flex-grow-1 form-container form-hilighter">
-        <Form
-          form={updatedForm}
-          options={{
-            viewAsHtml: true,
-            readOnly: true,
-          } as any}
-          // showHiddenFields={false}
-          formReady={(e) => {
-            formRef.current = e;
-          }}
-        />
-      </div>
+        <div 
+          ref={formHilighterRef} // Add ref to the form container
+          className="flex-grow-1 form-container form-hilighter"
+        >
+          <Form
+            form={updatedForm}
+            options={{
+              viewAsHtml: true,
+              readOnly: true,
+            } as any}
+            formReady={(e) => {
+              formRef.current = e;
+            }}
+          />
+        </div>
       </div>
     );
   }

--- a/forms-flow-components/src/components/CustomComponents/FormComponent.tsx
+++ b/forms-flow-components/src/components/CustomComponents/FormComponent.tsx
@@ -198,7 +198,7 @@ export const FormComponent: React.FC<FormComponentProps> = React.memo(
       if (!formHilighter) return; // Early return if element doesn't exist
 
       const handleOutsideClick = (event) => {
-        const clickedInsideForm = formHilighter.contains(event.target);
+        const clickedInsideForm = formHilighter?.contains(event.target);
         const clickedInsideDetails = detailsRef.current?.contains(event.target);
 
         if (!clickedInsideForm && !clickedInsideDetails) {
@@ -211,11 +211,11 @@ export const FormComponent: React.FC<FormComponentProps> = React.memo(
       };
 
       // Add event listeners
-      formHilighter.addEventListener("click", handleClick);
+      formHilighter?.addEventListener("click", handleClick);
       document.addEventListener("mousedown", handleOutsideClick);
 
       return () => {
-        formHilighter.removeEventListener("click", handleClick);
+        formHilighter?.removeEventListener("click", handleClick);
         document.removeEventListener("mousedown", handleOutsideClick);
       };
     }, [handleClick, setShowElement, detailsRef]);


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-5366
https://aottech.atlassian.net/browse/FWF-5330
# Changes
<!-- 
What are the main changes in the PR?
Give a high-level description of the changes.
#Examples: Added a search feature, Renaming several fields, etc.
-->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Use ref for form container

- Fix outside-click handling cleanup

- Improve selection logic dependencies

- Minor formatting and comments cleanup


___

### Diagram Walkthrough


```mermaid
flowchart LR
  FormComponent["FormComponent.tsx"]
  RefAdded["Add formHilighterRef"]
  ClickLogic["Update click/selection logic"]
  OutsideClick["Robust outside-click handling"]
  RenderDiv["Ref on form container div"]

  FormComponent -- "introduce useRef" --> RefAdded
  RefAdded -- "used in effect" --> OutsideClick
  FormComponent -- "adjust dependencies" --> ClickLogic
  ClickLogic -- "controls selection & highlighting" --> OutsideClick
  RefAdded -- "assigned to container" --> RenderDiv
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FormComponent.tsx</strong><dd><code>Ref-based highlighter and robust outside-click handling</code>&nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-components/src/components/CustomComponents/FormComponent.tsx

<ul><li>Add <code>formHilighterRef</code> and use it instead of querySelector.<br> <li> Improve outside-click handling with proper add/remove listeners.<br> <li> Adjust <code>useCallback</code> and <code>useEffect</code> dependency arrays.<br> <li> Minor cleanup: spacing, comments, and consistent variable names.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/824/files#diff-153b3c47f9db406688015d8ac74e4fa312c1e58caa13546ea3de41f1c9b03ee0">+34/-36</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

