### PR TITLE
FWF-5227 : [Modified] Added all roles with access to review table

### DIFF
--- a/forms-flow-review/src/components/TaskList/TasklistTable.tsx
+++ b/forms-flow-review/src/components/TaskList/TasklistTable.tsx
@@ -93,13 +93,18 @@ const TaskListTable = () => {
         return <TaskAssigneeManager task={task} />;
       case "roles": {
         const roleValues = candidateGroups.length > 0
-          ? candidateGroups.map(group => group?.groupId ?? "-")
+          ? candidateGroups.map(group => {
+            const groupId = group?.groupId ?? "-";
+            return removeTenantKey(groupId, tenantKey, MULTITENANCY_ENABLED);
+          })
           : ["-"];
 
         const allRoles = roleValues.join(",");
 
-        return removeTenantKey(allRoles, tenantKey, MULTITENANCY_ENABLED);
+        return allRoles;
       }
+
+
     }
   }
 


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: https://aottech.atlassian.net/browse/FWF-5227
Issue Type: BUG/ FEATURE

# Changes
<img width="1435" height="588" alt="image" src="https://github.com/user-attachments/assets/8aedb025-a390-4f39-85b0-c4feb30ea19c" />


___

### **PR Type**
Enhancement


___

### **Description**
- Show all candidate group roles

- Map and join group IDs cleanly

- Preserve tenant key removal logic

- Improve roles column readability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  rolesCol["Roles column renderer"] -- "map candidateGroups" --> roleIds["Extract groupId per group"]
  roleIds -- "removeTenantKey for each" --> cleanedIds["Tenantless role IDs"]
  cleanedIds -- "join with comma" --> displayValue["All roles string"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TasklistTable.tsx</strong><dd><code>Render all candidate group roles in roles column</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/TaskList/TasklistTable.tsx

<ul><li>Replace single role display with all roles.<br> <li> Map candidate groups, sanitize via removeTenantKey.<br> <li> Join roles into comma-separated string.<br> <li> Fallback to "-" when no groups exist.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/854/files#diff-8174abb611ee4ca2991835c9d9808bccfd09c8539aee8301cee367477b588564">+12/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

