### PR TITLE
FWF-5395: [Upgrade] Keycloak-js version upgrade

### DIFF
--- a/forms-flow-service/package-lock.json
+++ b/forms-flow-service/package-lock.json
@@ -13,7 +13,7 @@
         "@types/webpack-env": "^1.16.2",
         "axios": "^1.3.0",
         "i18next": "^23.2.11",
-        "keycloak-js": "^26.1.2",
+        "keycloak-js": "^26.2.1",
         "moment": "^2.29.4",
         "single-spa": "^5.9.3"
       },
@@ -6983,9 +6983,13 @@
       }
     },
     "node_modules/keycloak-js": {
-      "version": "26.1.4",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.1.4.tgz",
-      "integrity": "sha512-4h2RicCzIAtsjKIG8DIO+8NKlpWX2fiNkbS0jlbtjZFbIGGjbQBzjS/5NkyWlzxamXVow9prHTIgIiwfo3GAmQ=="
+      "version": "26.2.1",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.1.tgz",
+      "integrity": "sha512-bZt6fQj/TLBAmivXSxSlqAJxBx/knNZDQGJIW4ensGYGN4N6tUKV8Zj3Y7/LOV8eIpvWsvqV70fbACihK8Ze0Q==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "test"
+      ]
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -15449,9 +15453,9 @@
       }
     },
     "keycloak-js": {
-      "version": "26.1.4",
-      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.1.4.tgz",
-      "integrity": "sha512-4h2RicCzIAtsjKIG8DIO+8NKlpWX2fiNkbS0jlbtjZFbIGGjbQBzjS/5NkyWlzxamXVow9prHTIgIiwfo3GAmQ=="
+      "version": "26.2.1",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.2.1.tgz",
+      "integrity": "sha512-bZt6fQj/TLBAmivXSxSlqAJxBx/knNZDQGJIW4ensGYGN4N6tUKV8Zj3Y7/LOV8eIpvWsvqV70fbACihK8Ze0Q=="
     },
     "keyv": {
       "version": "4.5.4",

--- a/forms-flow-service/package.json
+++ b/forms-flow-service/package.json
@@ -48,7 +48,7 @@
     "@types/webpack-env": "^1.16.2",
     "axios": "^1.3.0",
     "i18next": "^23.2.11",
-    "keycloak-js": "^26.1.2",
+    "keycloak-js": "^26.2.1",
     "moment": "^2.29.4",
     "single-spa": "^5.9.3"
   },


### PR DESCRIPTION
### **User description**
# Issue Tracking

JIRA: 
Issue Type: BUG/ FEATURE
https://aottech.atlassian.net/browse/FWF-5395

# Changes

-  keycloak-js version upgraded to 26.2.1. 
- The latest available version of keycloak-js is 26.2.1. Since a corresponding 26.4.1 version is not yet available, the package was upgraded to 26.2.1 instead.


___

### **PR Type**
Enhancement


___

### **Description**
- Bump `keycloak-js` dependency to v26.2.1


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump keycloak-js dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-service/package.json

- Updated `keycloak-js` from ^26.1.2 to ^26.2.1


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/909/files#diff-fb40cca48e630cb2268d7e402873ba6579f648cac50aca062844d038e36d49e2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

