### PR TITLE
FWF-5908 [BUGFIX] - dropdown list not visible in modal

### DIFF
--- a/forms-flow-components/src/components/CustomComponents/SelectWithCustomValue.tsx
+++ b/forms-flow-components/src/components/CustomComponents/SelectWithCustomValue.tsx
@@ -201,12 +201,11 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
         // Handle click outside
         useEffect(() => {
             const handleClickOutside = (event: MouseEvent): void => {
-                if (
-                    dropdownRef.current &&
-                    !dropdownRef.current.contains(event.target as Node) &&
-                    (!primaryMenuRef.current ||
-                        !primaryMenuRef.current.contains(event.target as Node))
-                ) {
+                const target = event.target as Node;
+                const inDropdown = dropdownRef.current?.contains(target);
+                const inMenu = primaryMenuRef.current?.contains(target);
+                const inWrapper = primaryWrapperRef.current?.contains(target);
+                if (!inDropdown && !inMenu && !inWrapper) {
                     setIsOpen(false);
                     setSecondIsOpen(false);
                     setSearchTerm("");

--- a/forms-flow-components/src/components/CustomComponents/SelectWithCustomValue.tsx
+++ b/forms-flow-components/src/components/CustomComponents/SelectWithCustomValue.tsx
@@ -82,6 +82,50 @@ const buildClassNames = (
     ...classes: (string | false | null | undefined)[]
 ): string => classes.filter(Boolean).join(" ");
 
+type DisplayLabelParams = {
+    opts: SelectWithCustomValueOptionType[];
+    selValue: string | number | undefined;
+    defaultVal?: string | number;
+    placeholder?: string;
+};
+
+const getDisplayLabel = ({
+    opts,
+    selValue,
+    defaultVal,
+    placeholder = "",
+}: DisplayLabelParams): React.ReactNode => {
+    const selected = opts?.find((o) => o.value === selValue);
+    if (selected) {
+        return (
+            <span className="dropdown-text-content">
+                {selected.icon && <span className="dropdown-icon">{selected.icon}</span>}
+                <span>{selected.label}</span>
+            </span>
+        );
+    }
+
+    const defaultMatch = opts?.find((o) => o.value === defaultVal);
+    if (defaultMatch) {
+        return (
+            <span className="dropdown-text-content">
+                {defaultMatch.icon && <span className="dropdown-icon">{defaultMatch.icon}</span>}
+                <span>{defaultMatch.label}</span>
+            </span>
+        );
+    }
+
+    if (selValue && !opts?.some((o) => o.value === selValue)) {
+        return String(selValue);
+    }
+
+    if (!selValue && !defaultVal) {
+        return <span className="dropdown-text-placeholder">{placeholder}</span>;
+    }
+
+    return defaultVal ?? "";
+};
+
 /** Dropdown position interface */
 interface DropdownPosition {
     top: number;
@@ -150,6 +194,38 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
         const primaryMenuRef = useRef<HTMLDivElement | null>(null);
         const [primaryPosition, setPrimaryPosition] = useState<DropdownPosition | null>(null);
         const [isMounted, setIsMounted] = useState(false);
+
+        // --- Custom value mode helpers ---
+        const enterCustomMode = useCallback(
+            (initialValue: string = "") => {
+                setIsCustomValueMode(true);
+                setCustomInputValue(initialValue);
+                setShouldAutoFocus(true);
+                setIsOpen(false);
+                setSearchTerm("");
+            },
+            []
+        );
+
+        const commitCustomValue = useCallback(
+            (trimmedValue: string) => {
+                setSelectedValue(trimmedValue);
+                setIsCustomValueMode(false);
+                setShouldAutoFocus(false);
+                onChange?.(trimmedValue);
+            },
+            [onChange]
+        );
+
+        const cancelCustomModeAndShowDropdown = useCallback(() => {
+            setShouldAutoFocus(false);
+            setIsCustomValueMode(false);
+            setCustomInputValue("");
+            setSelectedValue(undefined);
+            setIsOpen(true);
+            setSearchTerm("");
+            // Don't call onChange with undefined - let user select a new value
+        }, []);
 
         // Update values if props change
         useEffect(() => {
@@ -222,16 +298,12 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
             if (!disabled) {
                 // If current value is a custom value (not in options), enter edit mode
                 if (selectedValue && !options.some(opt => opt.value === selectedValue)) {
-                    setIsCustomValueMode(true);
-                    setCustomInputValue(String(selectedValue));
-                    setShouldAutoFocus(true); // Enable autoFocus when entering edit mode
-                    setIsOpen(false);
-                    setSearchTerm("");
+                    enterCustomMode(String(selectedValue));
                 } else {
                     setIsOpen((prev) => !prev);
                 }
             }
-        }, [disabled, selectedValue, options]);
+        }, [disabled, selectedValue, options, enterCustomMode]);
 
         /** Handle secondary toggle */
         const handleSecondToggle = useCallback(() => {
@@ -302,16 +374,14 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
         const handleCustomValueClick = useCallback(() => {
             setIsOpen(false);
             setSearchTerm("");
-            setIsCustomValueMode(true);
-            setShouldAutoFocus(true); // Enable autoFocus when entering custom value mode
             // Set initial input value to current selected value if it's a string
-            if (selectedValue && typeof selectedValue === 'string') {
-                setCustomInputValue(selectedValue);
+            if (selectedValue && typeof selectedValue === "string") {
+                enterCustomMode(selectedValue);
             } else {
-                setCustomInputValue("");
+                enterCustomMode("");
             }
             onEnterCustomValue?.();
-        }, [onEnterCustomValue, selectedValue]);
+        }, [enterCustomMode, onEnterCustomValue, selectedValue]);
 
         const handleAdditionalVariablesClick = useCallback(() => {
             setIsOpen(false);
@@ -321,60 +391,200 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
             onSelectAdditionalVariables?.();
         }, [onSelectAdditionalVariables]);
 
-        /** Reset custom value mode and show dropdown */
-        const resetCustomValueModeAndShowDropdown = useCallback(() => {
-            setShouldAutoFocus(false);
-            setIsCustomValueMode(false);
-            setCustomInputValue("");
-            setSelectedValue(undefined);
-            setIsOpen(true);
-            setSearchTerm("");
-            // Don't call onChange with undefined - let user select a new value
-        }, []);
-
         /** Handle custom input value change for CustomTextInput (uses setValue callback) */
         const handleCustomInputSetValue = useCallback((newValue: string) => {
             setCustomInputValue(newValue);
             
             // If input is cleared, exit custom value mode and show dropdown
             if (newValue.trim() === "" && isCustomValueMode) {
-                resetCustomValueModeAndShowDropdown();
+                cancelCustomModeAndShowDropdown();
             }
-        }, [isCustomValueMode, resetCustomValueModeAndShowDropdown]);
+        }, [isCustomValueMode, cancelCustomModeAndShowDropdown]);
 
         /** Handle Enter key press in custom input */
         const handleCustomInputKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
             if (e.key === "Enter") {
                 e.preventDefault();
-                setShouldAutoFocus(false); // Disable autoFocus after Enter is pressed
                 const trimmedValue = customInputValue.trim();
                 if (trimmedValue) {
-                    setSelectedValue(trimmedValue);
-                    setIsCustomValueMode(false);
-                    onChange?.(trimmedValue);
+                    commitCustomValue(trimmedValue);
                 } else {
                     // If Enter is pressed with empty input, show dropdown
-                    resetCustomValueModeAndShowDropdown();
+                    cancelCustomModeAndShowDropdown();
                 }
             } else if (e.key === "Escape") {
                 // Exit custom value mode and show dropdown
-                resetCustomValueModeAndShowDropdown();
+                cancelCustomModeAndShowDropdown();
             }
-        }, [customInputValue, onChange, resetCustomValueModeAndShowDropdown]);
+        }, [commitCustomValue, customInputValue, cancelCustomModeAndShowDropdown]);
 
         /** Handle blur on custom input */
         const handleCustomInputBlur = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
-            setShouldAutoFocus(false); // Disable autoFocus after blur
             const trimmedValue = customInputValue.trim();
             if (trimmedValue) {
-                setSelectedValue(trimmedValue);
-                setIsCustomValueMode(false);
-                onChange?.(trimmedValue);
+                commitCustomValue(trimmedValue);
             } else {
                 // If input is empty, exit custom value mode and show dropdown
-                resetCustomValueModeAndShowDropdown();
+                cancelCustomModeAndShowDropdown();
             }
-        }, [customInputValue, onChange, resetCustomValueModeAndShowDropdown]);
+        }, [commitCustomValue, customInputValue, cancelCustomModeAndShowDropdown]);
+
+        const renderSpecialItems = (
+            itemClass: string | undefined,
+            showSpecialItems: boolean
+        ) => {
+            if (!showSpecialItems) return null;
+
+            return (
+                <>
+                    <ListGroup.Item
+                        className={buildClassNames(
+                            "custom-dropdown-item",
+                            "custom-dropdown-item-special",
+                            itemClass
+                        )}
+                        onClick={handleCustomValueClick}
+                        data-testid={`${dataTestId}-enter-custom-value`}
+                    >
+                        <span className="dropdown-option-content">
+                            <span>{customValueLabel}</span>
+                        </span>
+                    </ListGroup.Item>
+
+                    {onSelectAdditionalVariables && (
+                        <ListGroup.Item
+                            className={buildClassNames(
+                                "custom-dropdown-item",
+                                "custom-dropdown-item-special",
+                                itemClass
+                            )}
+                            onClick={handleAdditionalVariablesClick}
+                            data-testid={`${dataTestId}-select-additional-variables`}
+                        >
+                            <span className="dropdown-option-content">
+                                <span>{additionalVariablesLabel}</span>
+                            </span>
+                        </ListGroup.Item>
+                    )}
+                </>
+            );
+        };
+
+        const renderMenu = (
+            opts: SelectWithCustomValueOptionType[],
+            selValue: string | number | undefined,
+            selectFn: (value: string | number) => void,
+            variantType: SelectWithCustomValueVariant,
+            itemClass: string | undefined,
+            showSpecialItems: boolean,
+            menuRef?: React.MutableRefObject<HTMLDivElement | null>,
+            position?: DropdownPosition | null
+        ) => {
+            const shouldPortal = isMounted && position && typeof document !== "undefined";
+
+            const content = (
+                <div
+                    ref={(node) => {
+                        if (menuRef) {
+                            menuRef.current = node;
+                        }
+                    }}
+                    className={buildClassNames(
+                        "custom-dropdown-options",
+                        `custom-dropdown-options--${variantType}`
+                    )}
+                    style={
+                        shouldPortal && position
+                            ? {
+                                  position: "absolute",
+                                  top: position.top,
+                                  left: position.left,
+                                  width: position.width,
+                                  zIndex: 2000,
+                                  maxHeight: "10.75rem",
+                              }
+                            : undefined
+                    }
+                >
+                    {searchable && (
+                        <div className="custom-dropdown-search">
+                            <CustomSearch
+                                search={searchTerm}
+                                setSearch={setSearchTerm}
+                                handleSearch={() => {}}
+                                placeholder={customSearchPlaceholder}
+                                dataTestId={`${dataTestId}-dropdown-search`}
+                            />
+                        </div>
+                    )}
+
+                    {renderSpecialItems(itemClass, showSpecialItems)}
+
+                    {opts.length > 0 ? (
+                        opts.map((option) => (
+                            <ListGroup.Item
+                                key={option.value}
+                                className={buildClassNames(
+                                    "custom-dropdown-item",
+                                    itemClass,
+                                    option.value === selValue && "selected"
+                                )}
+                                onClick={() => selectFn(option.value)}
+                                aria-selected={option.value === selValue}
+                                data-testid={`${dataTestId}-${option.value}`}
+                            >
+                                <span className="dropdown-option-content">
+                                    {option.icon && (
+                                        <span className="dropdown-icon">{option.icon}</span>
+                                    )}
+                                    <span>{option.label}</span>
+                                </span>
+                            </ListGroup.Item>
+                        ))
+                    ) : (
+                        !showSpecialItems && (
+                            <ListGroup.Item className="custom-dropdown-item no-results">
+                                No Matching Results
+                            </ListGroup.Item>
+                        )
+                    )}
+                </div>
+            );
+
+            return { content, shouldPortal };
+        };
+
+        const renderButton = (
+            opts: SelectWithCustomValueOptionType[],
+            selValue: string | number | undefined,
+            isOpenState: boolean,
+            toggleFn: () => void,
+            variantType: SelectWithCustomValueVariant,
+            defaultVal?: string | number
+        ) => (
+            <button
+                type="button"
+                className={buildClassNames(
+                    "custom-selectdropdown",
+                    `custom-selectdropdown--${variantType}`,
+                    disabled && "disabled"
+                )}
+                onClick={toggleFn}
+                aria-expanded={isOpenState}
+                aria-haspopup="listbox"
+                disabled={disabled}
+            >
+                <span className="dropdown-text">
+                    {getDisplayLabel({
+                        opts,
+                        selValue,
+                        defaultVal,
+                        placeholder,
+                    })}
+                </span>
+                {renderArrowIcon(isOpenState)}
+            </button>
+        );
 
         /** Generic dropdown renderer (used for both primary and secondary) */
         const renderDropdown = (
@@ -392,192 +602,53 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
             menuRef?: React.MutableRefObject<HTMLDivElement | null>,
             position?: DropdownPosition | null
         ) => {
-            // Render custom input mode for primary dropdown only
             if (showSpecialItems && isCustomValueMode) {
                 return (
-                    <div 
+                    <div
                         ref={wrapperRef}
                         className={buildClassNames("dropdown-wrapper", wrapperClass)}
                         onKeyDown={handleCustomInputKeyDown}
                     >
-                            <CustomTextInput
-                                value={customInputValue}
-                                setValue={handleCustomInputSetValue}
-                                onBlur={handleCustomInputBlur}
-                                disabled={disabled}
-                                placeholder={placeholder}
-                                dataTestId={`${dataTestId}-custom-input`}
-                                autoFocus={shouldAutoFocus}
-                            />
+                        <CustomTextInput
+                            value={customInputValue}
+                            setValue={handleCustomInputSetValue}
+                            onBlur={handleCustomInputBlur}
+                            disabled={disabled}
+                            placeholder={placeholder}
+                            dataTestId={`${dataTestId}-custom-input`}
+                            autoFocus={shouldAutoFocus}
+                        />
                     </div>
                 );
             }
 
-            const shouldPortal =
-                isMounted && position && typeof document !== "undefined";
-            
-            const dropdownContent = (
-                <div
-                    ref={(node) => {
-                        if (menuRef) {
-                            menuRef.current = node;
-                        }
-                    }}
-                    className={buildClassNames(
-                        "custom-dropdown-options",
-                        `custom-dropdown-options--${variantType}`
-                    )}
-                    style={
-                        shouldPortal && position
-                            ? {
-                                position: "absolute",
-                                top: position.top,
-                                left: position.left,
-                                width: position.width,
-                                zIndex: 2000,
-                                maxHeight: "10.75rem",
-                            }
-                            : undefined
-                    }
-                >
-                        {searchable && (
-                            <div className="custom-dropdown-search">
-                                <CustomSearch
-                                    search={searchTerm}
-                                    setSearch={setSearchTerm}
-                                    handleSearch={() => { }}
-                                    placeholder={customSearchPlaceholder}
-                                    dataTestId={`${dataTestId}-dropdown-search`}
-                                />
-                            </div>
-                        )}
-                        {/* Special action items - always shown at top */}
-                        {showSpecialItems && (
-                            <>
-                                {(
-                                    <ListGroup.Item
-                                        className={buildClassNames(
-                                            "custom-dropdown-item",
-                                            "custom-dropdown-item-special",
-                                            itemClass
-                                        )}
-                                        onClick={handleCustomValueClick}
-                                        data-testid={`${dataTestId}-enter-custom-value`}
-                                    >
-                                        <span className="dropdown-option-content">
-                                            <span>{customValueLabel}</span>
-                                        </span>
-                                    </ListGroup.Item>
-                                )}
-
-                                {onSelectAdditionalVariables && (
-                                    <ListGroup.Item
-                                        className={buildClassNames(
-                                            "custom-dropdown-item",
-                                            "custom-dropdown-item-special",
-                                            itemClass
-                                        )}
-                                        onClick={handleAdditionalVariablesClick}
-                                        data-testid={`${dataTestId}-select-additional-variables`}
-                                    >
-                                        <span className="dropdown-option-content">
-                                            <span>{additionalVariablesLabel}</span>
-                                        </span>
-                                    </ListGroup.Item>
-                                )}
-                            </>
-                        )}
-                        {/* Regular options */}
-                        {opts.length > 0 ? (
-                            opts.map((option) => (
-                                <ListGroup.Item
-                                    key={option.value}
-                                    className={buildClassNames(
-                                        "custom-dropdown-item",
-                                        itemClass,
-                                        option.value === selValue && "selected"
-                                    )}
-                                    onClick={() => selectFn(option.value)}
-                                    aria-selected={option.value === selValue}
-                                    data-testid={`${dataTestId}-${option.value}`}
-                                >
-                                    <span className="dropdown-option-content">
-                                        {option.icon && (
-                                            <span className="dropdown-icon">{option.icon}</span>
-                                        )}
-                                        <span>{option.label}</span>
-                                    </span>
-                                </ListGroup.Item>
-                            ))
-                        ) : (
-                            !showSpecialItems && (
-                                <ListGroup.Item className="custom-dropdown-item no-results">
-                                    No Matching Results
-                                </ListGroup.Item>
-                            )
-                        )}
-                    </div>
-                );
+            const { content, shouldPortal } = renderMenu(
+                opts,
+                selValue,
+                selectFn,
+                variantType,
+                itemClass,
+                showSpecialItems,
+                menuRef,
+                position
+            );
 
             return (
-                <div 
+                <div
                     ref={wrapperRef}
                     className={buildClassNames("dropdown-wrapper", wrapperClass)}
                 >
-                    <button
-                        type="button"
-                        className={buildClassNames(
-                            "custom-selectdropdown",
-                            `custom-selectdropdown--${variantType}`,
-                            disabled && "disabled"
-                        )}
-                        onClick={toggleFn}
-                        aria-expanded={isOpenState}
-                        aria-haspopup="listbox"
-                        disabled={disabled}
-                    >
-                        <span className="dropdown-text">
-                            {(() => {
-                                const selected = opts?.find((o) => o.value === selValue);
-                                if (selected) {
-                                    return (
-                                        <span className="dropdown-text-content">
-                                            {selected.icon && (
-                                                <span className="dropdown-icon">{selected.icon}</span>
-                                            )}
-                                            <span>{selected.label}</span>
-                                        </span>
-                                    );
-                                }
-                                const defaultMatch = opts?.find((o) => o.value === defaultVal);
-                                if (defaultMatch) {
-                                    return (
-                                        <span className="dropdown-text-content">
-                                            {defaultMatch.icon && (
-                                                <span className="dropdown-icon">{defaultMatch.icon}</span>
-                                            )}
-                                            <span>{defaultMatch.label}</span>
-                                        </span>
-                                    );
-                                }
-                                // Show custom value if it exists and is not in options
-                                if (selValue && !opts?.some((o) => o.value === selValue)) {
-                                    return String(selValue);
-                                }
-                                // Show placeholder if no value is selected
-                                if (!selValue && !defaultVal) {
-                                    return <span className="dropdown-text-placeholder">{placeholder}</span>;
-                                }
-                                return defaultVal ?? "";
-                            })()}
-                        </span>
-                        {renderArrowIcon(isOpenState)}
-                    </button>
+                    {renderButton(
+                        opts,
+                        selValue,
+                        isOpenState,
+                        toggleFn,
+                        variantType,
+                        defaultVal
+                    )}
                     {isOpenState &&
                         !disabled &&
-                        (shouldPortal
-                            ? createPortal(dropdownContent, document.body)
-                            : dropdownContent)}
+                        (shouldPortal ? createPortal(content, document.body) : content)}
                 </div>
             );
         };

--- a/forms-flow-components/src/components/CustomComponents/SelectWithCustomValue.tsx
+++ b/forms-flow-components/src/components/CustomComponents/SelectWithCustomValue.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo, forwardRef, memo } from "react";
+import { createPortal } from "react-dom";
 import { DownArrowIcon, UpArrowIcon, VerticalLineIcon } from "../SvgIcons";
 import { ListGroup } from "react-bootstrap";
 import { CustomSearch } from "./Search";
@@ -81,6 +82,13 @@ const buildClassNames = (
     ...classes: (string | false | null | undefined)[]
 ): string => classes.filter(Boolean).join(" ");
 
+/** Dropdown position interface */
+interface DropdownPosition {
+    top: number;
+    left: number;
+    width: number;
+}
+
 /** SelectWithCustomValue Component */
 const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCustomValueProps>(
     (
@@ -138,6 +146,10 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
         >(secondValue || secondDefaultValue);
 
         const dropdownRef = useRef<HTMLDivElement>(null);
+        const primaryWrapperRef = useRef<HTMLDivElement>(null);
+        const primaryMenuRef = useRef<HTMLDivElement | null>(null);
+        const [primaryPosition, setPrimaryPosition] = useState<DropdownPosition | null>(null);
+        const [isMounted, setIsMounted] = useState(false);
 
         // Update values if props change
         useEffect(() => {
@@ -154,12 +166,46 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
             setSecondSelectedValue(secondValue || secondDefaultValue);
         }, [secondValue, secondDefaultValue]);
 
+        useEffect(() => {
+            setIsMounted(typeof document !== "undefined");
+        }, []);
+
+        const updatePosition = useCallback(
+            (
+                wrapper: React.RefObject<HTMLDivElement>,
+                setter: React.Dispatch<React.SetStateAction<DropdownPosition | null>>
+            ) => {
+                if (!wrapper.current) return;
+                const rect = wrapper.current.getBoundingClientRect();
+                setter({
+                    top: rect.bottom + window.scrollY,
+                    left: rect.left + window.scrollX,
+                    width: rect.width,
+                });
+            },
+            []
+        );
+
+        useEffect(() => {
+            if (!isOpen) return;
+            const handleUpdate = () => updatePosition(primaryWrapperRef, setPrimaryPosition);
+            handleUpdate();
+            window.addEventListener("scroll", handleUpdate, true);
+            window.addEventListener("resize", handleUpdate);
+            return () => {
+                window.removeEventListener("scroll", handleUpdate, true);
+                window.removeEventListener("resize", handleUpdate);
+            };
+        }, [isOpen, updatePosition]);
+
         // Handle click outside
         useEffect(() => {
             const handleClickOutside = (event: MouseEvent): void => {
                 if (
                     dropdownRef.current &&
-                    !dropdownRef.current.contains(event.target as Node)
+                    !dropdownRef.current.contains(event.target as Node) &&
+                    (!primaryMenuRef.current ||
+                        !primaryMenuRef.current.contains(event.target as Node))
                 ) {
                     setIsOpen(false);
                     setSecondIsOpen(false);
@@ -342,12 +388,16 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
             defaultVal?: string | number,
             wrapperClass?: string,
             itemClass?: string,
-            showSpecialItems: boolean = false
+            showSpecialItems: boolean = false,
+            wrapperRef?: React.RefObject<HTMLDivElement>,
+            menuRef?: React.MutableRefObject<HTMLDivElement | null>,
+            position?: DropdownPosition | null
         ) => {
             // Render custom input mode for primary dropdown only
             if (showSpecialItems && isCustomValueMode) {
                 return (
                     <div 
+                        ref={wrapperRef}
                         className={buildClassNames("dropdown-wrapper", wrapperClass)}
                         onKeyDown={handleCustomInputKeyDown}
                     >
@@ -364,64 +414,33 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
                 );
             }
 
-            return (
-                <div className={buildClassNames("dropdown-wrapper", wrapperClass)}>
-                    <button
-                        type="button"
-                        className={buildClassNames(
-                            "custom-selectdropdown",
-                            `custom-selectdropdown--${variantType}`,
-                            disabled && "disabled"
-                        )}
-                        onClick={toggleFn}
-                        aria-expanded={isOpenState}
-                        aria-haspopup="listbox"
-                        disabled={disabled}
-                    >
-                        <span className="dropdown-text">
-                            {(() => {
-                                const selected = opts?.find((o) => o.value === selValue);
-                                if (selected) {
-                                    return (
-                                        <span className="dropdown-text-content">
-                                            {selected.icon && (
-                                                <span className="dropdown-icon">{selected.icon}</span>
-                                            )}
-                                            <span>{selected.label}</span>
-                                        </span>
-                                    );
-                                }
-                                const defaultMatch = opts?.find((o) => o.value === defaultVal);
-                                if (defaultMatch) {
-                                    return (
-                                        <span className="dropdown-text-content">
-                                            {defaultMatch.icon && (
-                                                <span className="dropdown-icon">{defaultMatch.icon}</span>
-                                            )}
-                                            <span>{defaultMatch.label}</span>
-                                        </span>
-                                    );
-                                }
-                                // Show custom value if it exists and is not in options
-                                if (selValue && !opts?.some((o) => o.value === selValue)) {
-                                    return String(selValue);
-                                }
-                                // Show placeholder if no value is selected
-                                if (!selValue && !defaultVal) {
-                                    return <span className="dropdown-text-placeholder">{placeholder}</span>;
-                                }
-                                return defaultVal ?? "";
-                            })()}
-                        </span>
-                        {renderArrowIcon(isOpenState)}
-                    </button>
-                {isOpenState && !disabled && (
-                    <div
-                        className={buildClassNames(
-                            "custom-dropdown-options",
-                            `custom-dropdown-options--${variantType}`
-                        )}
-                    >
+            const shouldPortal =
+                isMounted && position && typeof document !== "undefined";
+            
+            const dropdownContent = (
+                <div
+                    ref={(node) => {
+                        if (menuRef) {
+                            menuRef.current = node;
+                        }
+                    }}
+                    className={buildClassNames(
+                        "custom-dropdown-options",
+                        `custom-dropdown-options--${variantType}`
+                    )}
+                    style={
+                        shouldPortal && position
+                            ? {
+                                position: "absolute",
+                                top: position.top,
+                                left: position.left,
+                                width: position.width,
+                                zIndex: 2000,
+                                maxHeight: "10.75rem",
+                            }
+                            : undefined
+                    }
+                >
                         {searchable && (
                             <div className="custom-dropdown-search">
                                 <CustomSearch
@@ -499,8 +518,68 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
                             )
                         )}
                     </div>
-                )}
-            </div>
+                );
+
+            return (
+                <div 
+                    ref={wrapperRef}
+                    className={buildClassNames("dropdown-wrapper", wrapperClass)}
+                >
+                    <button
+                        type="button"
+                        className={buildClassNames(
+                            "custom-selectdropdown",
+                            `custom-selectdropdown--${variantType}`,
+                            disabled && "disabled"
+                        )}
+                        onClick={toggleFn}
+                        aria-expanded={isOpenState}
+                        aria-haspopup="listbox"
+                        disabled={disabled}
+                    >
+                        <span className="dropdown-text">
+                            {(() => {
+                                const selected = opts?.find((o) => o.value === selValue);
+                                if (selected) {
+                                    return (
+                                        <span className="dropdown-text-content">
+                                            {selected.icon && (
+                                                <span className="dropdown-icon">{selected.icon}</span>
+                                            )}
+                                            <span>{selected.label}</span>
+                                        </span>
+                                    );
+                                }
+                                const defaultMatch = opts?.find((o) => o.value === defaultVal);
+                                if (defaultMatch) {
+                                    return (
+                                        <span className="dropdown-text-content">
+                                            {defaultMatch.icon && (
+                                                <span className="dropdown-icon">{defaultMatch.icon}</span>
+                                            )}
+                                            <span>{defaultMatch.label}</span>
+                                        </span>
+                                    );
+                                }
+                                // Show custom value if it exists and is not in options
+                                if (selValue && !opts?.some((o) => o.value === selValue)) {
+                                    return String(selValue);
+                                }
+                                // Show placeholder if no value is selected
+                                if (!selValue && !defaultVal) {
+                                    return <span className="dropdown-text-placeholder">{placeholder}</span>;
+                                }
+                                return defaultVal ?? "";
+                            })()}
+                        </span>
+                        {renderArrowIcon(isOpenState)}
+                    </button>
+                    {isOpenState &&
+                        !disabled &&
+                        (shouldPortal
+                            ? createPortal(dropdownContent, document.body)
+                            : dropdownContent)}
+                </div>
             );
         };
 
@@ -547,7 +626,10 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
                     defaultValue,
                     dropdownWrapperClassName,
                     dropdownItemClassName,
-                    true // Show special items for primary dropdown
+                    true, // Show special items for primary dropdown
+                    primaryWrapperRef,
+                    primaryMenuRef,
+                    primaryPosition
                 )}
 
                 {/* --- SECONDARY DROPDOWN (Indented) --- */}
@@ -567,7 +649,8 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
                                 "secondary",
                                 secondDefaultValue,
                                 dropdownWrapperClassName,
-                                dropdownItemClassName
+                                dropdownItemClassName,
+                                false, // Show special items for secondary dropdown
                             )}
                         </div>
                     </div>

--- a/forms-flow-components/src/components/CustomComponents/SelectWithCustomValue.tsx
+++ b/forms-flow-components/src/components/CustomComponents/SelectWithCustomValue.tsx
@@ -195,37 +195,45 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
         const [primaryPosition, setPrimaryPosition] = useState<DropdownPosition | null>(null);
         const [isMounted, setIsMounted] = useState(false);
 
+        // --- Common state transition helpers ---
+        const closeDropdownAndClearSearch = useCallback(() => {
+            setIsOpen(false);
+            setSearchTerm("");
+        }, []);
+
+        const exitCustomMode = useCallback(() => {
+            setIsCustomValueMode(false);
+            setShouldAutoFocus(false);
+        }, []);
+
         // --- Custom value mode helpers ---
         const enterCustomMode = useCallback(
             (initialValue: string = "") => {
                 setIsCustomValueMode(true);
                 setCustomInputValue(initialValue);
                 setShouldAutoFocus(true);
-                setIsOpen(false);
-                setSearchTerm("");
+                closeDropdownAndClearSearch();
             },
-            []
+            [closeDropdownAndClearSearch]
         );
 
         const commitCustomValue = useCallback(
             (trimmedValue: string) => {
                 setSelectedValue(trimmedValue);
-                setIsCustomValueMode(false);
-                setShouldAutoFocus(false);
+                exitCustomMode();
                 onChange?.(trimmedValue);
             },
-            [onChange]
+            [onChange, exitCustomMode]
         );
 
         const cancelCustomModeAndShowDropdown = useCallback(() => {
-            setShouldAutoFocus(false);
-            setIsCustomValueMode(false);
+            exitCustomMode();
             setCustomInputValue("");
             setSelectedValue(undefined);
             setIsOpen(true);
             setSearchTerm("");
             // Don't call onChange with undefined - let user select a new value
-        }, []);
+        }, [exitCustomMode]);
 
         // Update values if props change
         useEffect(() => {
@@ -282,16 +290,15 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
                 const inMenu = primaryMenuRef.current?.contains(target);
                 const inWrapper = primaryWrapperRef.current?.contains(target);
                 if (!inDropdown && !inMenu && !inWrapper) {
-                    setIsOpen(false);
+                    closeDropdownAndClearSearch();
                     setSecondIsOpen(false);
-                    setSearchTerm("");
                 }
             };
             document.addEventListener("mousedown", handleClickOutside);
             return () => {
                 document.removeEventListener("mousedown", handleClickOutside);
             };
-        }, []);
+        }, [closeDropdownAndClearSearch]);
 
         /** Handle primary toggle */
         const handleToggle = useCallback(() => {
@@ -314,10 +321,8 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
         const handleOptionClick = useCallback(
             (optionValue: string | number): void => {
                 setSelectedValue(optionValue);
-                setIsOpen(false);
-                setSearchTerm("");
-                setIsCustomValueMode(false); // Exit custom value mode when selecting an option
-                setShouldAutoFocus(false); // Reset autoFocus when selecting an option
+                closeDropdownAndClearSearch();
+                exitCustomMode();
                 onChange?.(optionValue);
 
                 // Reset dependent dropdown when parent changes
@@ -327,7 +332,7 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
                     setSecondSelectedValue('');
                 }
             },
-            [onChange, secondDropdown, dependentOptions, onSecondChange]
+            [onChange, secondDropdown, dependentOptions, onSecondChange, closeDropdownAndClearSearch, exitCustomMode]
         );
 
         /** Handle secondary select */
@@ -372,8 +377,6 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
 
         /** Handle special action items */
         const handleCustomValueClick = useCallback(() => {
-            setIsOpen(false);
-            setSearchTerm("");
             // Set initial input value to current selected value if it's a string
             if (selectedValue && typeof selectedValue === "string") {
                 enterCustomMode(selectedValue);
@@ -384,12 +387,10 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
         }, [enterCustomMode, onEnterCustomValue, selectedValue]);
 
         const handleAdditionalVariablesClick = useCallback(() => {
-            setIsOpen(false);
-            setSearchTerm("");
-            setIsCustomValueMode(false); // Exit custom value mode if active
-            setShouldAutoFocus(false); // Reset autoFocus when selecting additional variables
+            closeDropdownAndClearSearch();
+            exitCustomMode();
             onSelectAdditionalVariables?.();
-        }, [onSelectAdditionalVariables]);
+        }, [onSelectAdditionalVariables, closeDropdownAndClearSearch, exitCustomMode]);
 
         /** Handle custom input value change for CustomTextInput (uses setValue callback) */
         const handleCustomInputSetValue = useCallback((newValue: string) => {


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
Dropdown in the conditions modal is not visible properly

**Related Jira Ticket:**  
[https://aottech.atlassian.net/browse/FWF-5908](https://aottech.atlassian.net/browse/FWF-5908)

**Type of Change:**
- [ ] ✨ Feature
- [x] 🐞 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 📦 Dependency Update
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config / Security Updates

---

## 🧩 Microfrontends Affected

Please select all microfrontends or modules that are part of this change:

- [ ] forms-flow-admin  
- [x] forms-flow-components  
- [ ] forms-flow-integration  
- [ ] forms-flow-nav  
- [ ] forms-flow-review  
- [ ] forms-flow-service  
- [ ] forms-flow-submissions  
- [ ] forms-flow-theme  
- [ ] scripts  
- [ ] Others (please specify below)

**Details (if Others selected):**
<!-- Mention additional modules or new MFs impacted. -->

---

## 🧠 Summary of Changes
Added portal functionality to display the dropdown list

---

## 🧪 Testing Details

**Testing Performed:**
<!-- Describe testing done: manual, automated, cross-browser, etc. -->

**Screenshots (if applicable):**
Before:
<img width="1434" height="694" alt="image" src="https://github.com/user-attachments/assets/12285379-3565-4984-917f-28b55b1e36b1" />


After:
<img width="1021" height="720" alt="image" src="https://github.com/user-attachments/assets/99527540-1479-4507-843f-2f1ada272608" />


---

## ✅ Checklist

- [x] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated  
- [ ] Integration or end-to-end tests validated  
- [x] UI verified 
- [ ] Documentation updated (README / Confluence / UI Docs)  
- [x] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [x] I have given a **clear and meaningful PR title and description**  
- [x] I have verified **cross-repo dependencies** (if any)  
- [x] I have confirmed **backward compatibility** with previous releases  
- [x] Verified changes across all selected **microfrontends**

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers (e.g., areas to focus on, specific testing steps). -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add portal rendering for dropdown menus

- Fix click-outside handling with portaled menu

- Refactor custom value mode helpers

- Reduce duplication via render utilities


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Btn["Dropdown button"] -- "toggle" --> Menu["Menu content"]
  Menu -- "render via createPortal" --> Body["document.body"]
  Wrapper["Wrapper refs & position"] -- "compute rect" --> Position["Absolute coords"]
  Position -- "style" --> Menu
  CustomMode["Custom value mode"] -- "commit/cancel helpers" --> State["Selection state"]
  OutsideClick["Global mousedown"] -- "not in wrapper/menu" --> Close["Close dropdown & clear search"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SelectWithCustomValue.tsx</strong><dd><code>Portal dropdowns, positioning, and refactor helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-components/src/components/CustomComponents/SelectWithCustomValue.tsx

<ul><li>Introduce portal rendering for dropdown menu with absolute <br>positioning.<br> <li> Add refs and position tracking on scroll/resize; enhance outside click <br>handling.<br> <li> Extract helpers for display label, custom mode enter/commit/cancel, <br>and shared renderers.<br> <li> Reduce duplication by splitting renderButton/renderMenu and special <br>items renderer.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1083/files#diff-ec7b637cf48a1b97dcff8b31b330e0abaca6055ddb93e1bb6ca5cf58ed220f0d">+361/-207</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

