### PR TITLE
FWF-6046 [FEATURE]-Replaced Table Empty State

### DIFF
--- a/forms-flow-components/src/components/CustomComponents/EmptyState.tsx
+++ b/forms-flow-components/src/components/CustomComponents/EmptyState.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { V8CustomButton } from "./CustomButton";
+
+export interface EmptyStateAction {
+  label: string;
+  onClick: () => void;
+  variant?: "primary" | "secondary";
+  size?: "small" | "medium" | "large";
+  dataTestId?: string;
+}
+
+export interface EmptyStateProps {
+  message: string;
+  action?: EmptyStateAction;
+  className?: string;
+  dataTestId?: string;
+}
+
+/**
+ * Reusable EmptyState component for displaying empty states in tables and lists
+ * Supports customizable messages and optional action buttons
+ */
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  message,
+  action,
+  className = "",
+  dataTestId = "empty-state",
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className={`reusable-table-empty-state ${className}`}
+      data-testid={dataTestId}
+      role="status"
+      aria-live="polite"
+    >
+      <p className="reusable-table-empty-state-message">{t(message)}</p>
+      {action && (
+        <div className="reusable-table-empty-state-action">
+          <V8CustomButton
+            variant={action.variant || "primary"}
+            size={action.size || "medium"}
+            label={t(action.label)}
+            onClick={action.onClick}
+            dataTestId={action.dataTestId || "empty-state-action-button"}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default EmptyState;

--- a/forms-flow-components/src/components/CustomComponents/ReusableTable.tsx
+++ b/forms-flow-components/src/components/CustomComponents/ReusableTable.tsx
@@ -4,6 +4,7 @@ import Paper from "@mui/material/Paper";
 import { useTranslation } from "react-i18next";
 import { NewSortDownIcon } from "../SvgIcons";
 import { StyleServices } from "@formsflow/service";
+import { EmptyState, EmptyStateAction } from "./EmptyState";
 
 interface ReusableTableProps {
   columns: any[];
@@ -20,6 +21,8 @@ interface ReusableTableProps {
   sx?: object;
   dataGridProps?: object;
   noRowsLabel?: string;
+  emptyStateMessage?: string;
+  emptyStateAction?: EmptyStateAction;
   disableColumnResize?: boolean;
   disableColumnMenu?: boolean;
   disableRowSelectionOnClick?: boolean;
@@ -51,6 +54,8 @@ export const ReusableTable: React.FC<ReusableTableProps> = ({
   sx = { height: "100%", width: "100%" },
   dataGridProps = {},
   noRowsLabel,
+  emptyStateMessage,
+  emptyStateAction,
   disableColumnResize = true,
   disableColumnMenu = true,
   disableRowSelectionOnClick = true,
@@ -69,28 +74,56 @@ export const ReusableTable: React.FC<ReusableTableProps> = ({
   const { t } = useTranslation();
   const iconColor = StyleServices.getCSSVariable('--ff-gray-medium-dark');
 
-  const defaultSlots = useMemo(() => ({
-    columnSortedDescendingIcon: () => (
-      <div>
-        <NewSortDownIcon color={iconColor} />
-      </div>
-    ),
-    columnSortedAscendingIcon: () => (
-      <div style={{ transform: "rotate(180deg)" }}>
-        <NewSortDownIcon color={iconColor} />
-      </div>
-    ),
-    ...customSlots,
-  }), [iconColor, customSlots]);
+  // Create empty state overlay slot if emptyStateMessage or emptyStateAction is provided
+  const emptyStateOverlay = useMemo(() => {
+    if (emptyStateMessage || emptyStateAction) {
+      return () => (
+        <EmptyState
+          message={emptyStateMessage || noRowsLabel || "No data available"}
+          action={emptyStateAction}
+          dataTestId="reusable-table-empty-state"
+        />
+      );
+    }
+    return undefined;
+  }, [emptyStateMessage, emptyStateAction, noRowsLabel]);
+
+  const defaultSlots = useMemo(() => {
+    const slots: any = {
+      columnSortedDescendingIcon: () => (
+        <div>
+          <NewSortDownIcon color={iconColor} />
+        </div>
+      ),
+      columnSortedAscendingIcon: () => (
+        <div style={{ transform: "rotate(180deg)" }}>
+          <NewSortDownIcon color={iconColor} />
+        </div>
+      ),
+    };
+
+    // Add empty state overlay if provided and not already in customSlots
+    if (emptyStateOverlay && !(customSlots as any)?.noRowsOverlay) {
+      slots.noRowsOverlay = emptyStateOverlay;
+    }
+
+    // Merge with custom slots (custom slots take precedence)
+    return {
+      ...slots,
+      ...customSlots,
+    };
+  }, [iconColor, customSlots, emptyStateOverlay]);
 
   const defaultSlotProps = useMemo(() => ({
     ...customSlotProps,
   }), [customSlotProps]);
 
-  const defaultLocaleText = useMemo(() => ({
-    noRowsLabel: noRowsLabel || t("No data available"),
-    ...customLocaleText,
-  }), [noRowsLabel, customLocaleText, t]);
+  const defaultLocaleText = useMemo(() => {
+    return {
+      noRowsLabel: noRowsLabel || t("No data available"),
+      ...customLocaleText,
+    };
+  }, [noRowsLabel, customLocaleText, t]);
 
   // Enhanced columns - modify first column to render expansion content
   const enhancedColumns: GridColDef[] = useMemo(() => {

--- a/forms-flow-components/src/components/index.ts
+++ b/forms-flow-components/src/components/index.ts
@@ -55,6 +55,7 @@ export { default as FileUploadPanel } from "./CustomComponents/FileUploadPanel";
 export * from "./CustomComponents/FilterDropDown";
 export { CustomCheckbox } from "./CustomComponents/CustomCheckbox";
 export * from "./CustomComponents/ReusableTable";
+export * from "./CustomComponents/EmptyState";
 export * from "./CustomComponents/ReusableLargeModal";
 export * from "./CustomComponents/FormViewModal";
 export * from "./CustomComponents/ReusableStandardModal";

--- a/forms-flow-review/src/components/TaskList/TasklistTable.tsx
+++ b/forms-flow-review/src/components/TaskList/TasklistTable.tsx
@@ -22,6 +22,7 @@ import {
   setBundleLoading,
   setAppHistoryLoading,
   setSelectedFilter,
+  setFilterToEdit,
 } from "../../actions/taskActions";
 import { MULTITENANCY_ENABLED } from "../../constants";
 import { useHistory, useParams } from "react-router-dom";
@@ -58,6 +59,7 @@ import { buildDynamicColumns, optionSortBy } from "../../helper/tableHelper";
 import { createReqPayload,sortableKeysSet } from "../../helper/taskHelper";
 import { removeTenantKey } from "../../helper/helper";
 import Loading from "../Loading/Loading";
+import TaskFilterModal from "../TaskFilterModal/TaskFilterModal";
 
 export interface Task {
   id: string;
@@ -108,6 +110,7 @@ const TaskListTable = () => {
     submissionId: "",
   });
   const [bundleName, setBundleName] = useState("");
+  const [showTaskFilterModal, setShowTaskFilterModal] = useState(false);
 
   // Redux selectors for task details
   const task = useSelector((state: any) => state.task.taskDetail);
@@ -621,6 +624,15 @@ const TaskListTable = () => {
   // Wrapper class to enable multi-line cell styles via CSS
   const tableWrapperClass = isMultiLineEnabled ? 'task-table-multiline' : '';
 
+  const handleCloseFilterModal = () => {
+    setShowTaskFilterModal(false);
+    dispatch(setFilterToEdit(null));
+  };
+
+  const handleToggleFilterModal = () => {
+    setShowTaskFilterModal((prev) => !prev);
+  };
+
   return (
     <>
       <div className={tableWrapperClass}>
@@ -637,7 +649,14 @@ const TaskListTable = () => {
           onPaginationModelChange={handlePaginationModelChange}
           sortModel={sortModel}
           onSortModelChange={handleSortModelChange}
-          noRowsLabel={t("No tasks found")}
+          emptyStateMessage="No tasks found"
+          emptyStateAction={{
+            label: t("Create custom Filter"),
+            onClick: handleToggleFilterModal,
+            variant: "primary",
+            size: "medium",
+            dataTestId: "create-custom-filter-button"
+          }}
           disableColumnMenu
           disableRowSelectionOnClick
           dataGridProps={{
@@ -689,6 +708,11 @@ const TaskListTable = () => {
           onRefresh={handleRefresh}
         />
       )}
+      <TaskFilterModal
+        toggleModal={handleToggleFilterModal}
+        show={showTaskFilterModal}
+        onClose={handleCloseFilterModal}
+      />
     </>
   );
 };

--- a/forms-flow-submissions/src/Routes/SubmissionListing.tsx
+++ b/forms-flow-submissions/src/Routes/SubmissionListing.tsx
@@ -1009,9 +1009,14 @@ const fetchSubmissions = useCallback(async () => {
             sortingMode="server"
             sortModel={sortModel}
             onSortModelChange={handleSortModelChange}
-            noRowsLabel={t(
-                "No submissions have been found. Try a different filter combination or contact your admin."
-              )}
+            emptyStateMessage="No submissions found"
+            emptyStateAction={{
+              label: t("Clear filters"),
+              onClick: handleResetToDefault,
+              variant: "primary",
+              size: "medium",
+              dataTestId: "clear-filters-button"
+            }}
             disableColumnMenu
             disableRowSelectionOnClick
             paginationModel={paginationModel}

--- a/forms-flow-theme/scss/v8-scss/_table.scss
+++ b/forms-flow-theme/scss/v8-scss/_table.scss
@@ -392,3 +392,17 @@ $table-shadow: rgba(0, 0, 0, 0.25); // Shadow color
 .MuiDataGrid-main {
   overflow-x: scroll!important;
 }
+
+.MuiDataGrid-overlayWrapper {
+  .MuiDataGrid-overlayWrapperInner{
+    height: max-content !important;
+    width: 70vw !important;
+    padding: 2rem;
+    .reusable-table-empty-state{
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      flex-direction: column;
+    }
+  }
+}


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
Generic table empty states replaced 

**Related Jira Ticket:**  
[https://aottech.atlassian.net/browse/FWF-6046](https://aottech.atlassian.net/browse/FWF-6046)

**Type of Change:**
- [x] ✨ Feature
- [ ] 🐞 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 📦 Dependency Update
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config / Security Updates

---

## 🧩 Microfrontends Affected

Please select all microfrontends or modules that are part of this change:

- [ ] forms-flow-admin  
- [x] forms-flow-components  
- [ ] forms-flow-integration  
- [ ] forms-flow-nav  
- [x] forms-flow-review  
- [ ] forms-flow-service  
- [x] forms-flow-submissions  
- [x] forms-flow-theme  
- [ ] scripts  
- [ ] Others (please specify below)

**Details (if Others selected):**
<!-- Mention additional modules or new MFs impacted. -->

---

## 🧠 Summary of Changes
General message for empty table replaced with proper message and button for the appropriate action

---

## 🧪 Testing Details

**Testing Performed:**
<!-- Describe testing done: manual, automated, cross-browser, etc. -->

**Screenshots (if applicable):**
Before:

<img width="1458" height="824" alt="image" src="https://github.com/user-attachments/assets/af45d37e-b372-464d-97a6-06786a84c4f2" />

<img width="1421" height="723" alt="image" src="https://github.com/user-attachments/assets/08c2ff3e-cc84-4655-87e4-d228a3a0a5a8" />

<img width="1470" height="635" alt="image" src="https://github.com/user-attachments/assets/ae7e226f-b785-4df2-9cba-9cd061a2ad64" />

<img width="1458" height="756" alt="image" src="https://github.com/user-attachments/assets/af48ca7a-6141-4721-9616-eb5f98ce17ab" />


AFTER:

<img width="1485" height="713" alt="image" src="https://github.com/user-attachments/assets/841df609-0473-4ba8-a848-6b0877e2ff6c" />

<img width="1440" height="631" alt="image" src="https://github.com/user-attachments/assets/553ad254-2a1e-4593-b563-55a88cf3b104" />

<img width="1435" height="773" alt="image" src="https://github.com/user-attachments/assets/b68bfae6-ca33-405f-ae04-8f94421f0ca0" />


<img width="1482" height="804" alt="image" src="https://github.com/user-attachments/assets/a62d4b85-8ab7-47ed-a6b0-b2b94d4272e3" />


---

## ✅ Checklist

- [x] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated  
- [ ] Integration or end-to-end tests validated  
- [x] UI verified 
- [ ] Documentation updated (README / Confluence / UI Docs)  
- [x] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [x] I have given a **clear and meaningful PR title and description**  
- [x] I have verified **cross-repo dependencies** (if any)  
- [x] I have confirmed **backward compatibility** with previous releases  
- [x] Verified changes across all selected **microfrontends**

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers (e.g., areas to focus on, specific testing steps). -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add reusable `EmptyState` component with action

- Extend `ReusableTable` with empty overlay

- Update task/submission tables empty actions

- Style DataGrid overlay empty layout


___

### Diagram Walkthrough


```mermaid
flowchart LR
  es["`EmptyState` component"]
  rt["`ReusableTable` no-rows overlay slot"]
  tl["Review: `TaskListTable` empty action"]
  sl["Submissions: `SubmissionListing` empty action"]
  css["Theme: DataGrid overlay styling"]

  es -- "rendered by" --> rt
  rt -- "used in" --> tl
  rt -- "used in" --> sl
  css -- "styles" --> es
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>EmptyState.tsx</strong><dd><code>Introduce reusable EmptyState with action button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-components/src/components/CustomComponents/EmptyState.tsx

<ul><li>Add <code>EmptyState</code> component with i18n message<br> <li> Support optional action via <code>EmptyStateAction</code><br> <li> Provide test ids and ARIA live region</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1112/files#diff-2959d5b94348ff0f53645d8e698cec6b27c1f497e0602add038b77924883fae4">+55/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ReusableTable.tsx</strong><dd><code>Add configurable empty overlay to ReusableTable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-components/src/components/CustomComponents/ReusableTable.tsx

<ul><li>Add <code>emptyStateMessage</code> and <code>emptyStateAction</code> props<br> <li> Create <code>noRowsOverlay</code> slot using <code>EmptyState</code><br> <li> Respect <code>customSlots.noRowsOverlay</code> precedence</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1112/files#diff-ae23aadec2c27b984989170e66f886480a184c0c8307ce64d695d1a677be4d1d">+50/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Export EmptyState from components entrypoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-components/src/components/index.ts

- Re-export `EmptyState` and related types


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1112/files#diff-1ed9e53c9f8295b5b3021997184e36e78ae685c06246d9cd6e9c4be1c350b116">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TasklistTable.tsx</strong><dd><code>Add task list empty action to create filter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/TaskList/TasklistTable.tsx

<ul><li>Add local state for <code>TaskFilterModal</code> visibility<br> <li> Dispatch <code>setFilterToEdit(null)</code> on close<br> <li> Use <code>ReusableTable</code> empty state with action button<br> <li> Render <code>TaskFilterModal</code> with toggle handlers</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1112/files#diff-8174abb611ee4ca2991835c9d9808bccfd09c8539aee8301cee367477b588564">+25/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SubmissionListing.tsx</strong><dd><code>Add submissions empty action to clear filters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-submissions/src/Routes/SubmissionListing.tsx

<ul><li>Replace <code>noRowsLabel</code> with empty state message<br> <li> Add empty action button calling <code>handleResetToDefault</code></ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1112/files#diff-1e75247435a3a424e8e37d4217fab202a48aa06804a6c1188407b0a34f27d909">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_table.scss</strong><dd><code>Style DataGrid overlay wrapper for empty states</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-theme/scss/v8-scss/_table.scss

<ul><li>Set overlay inner sizing and padding<br> <li> Center <code>.reusable-table-empty-state</code> content vertically</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1112/files#diff-0070db8a727504c2d5b33ca47f867568c11cbb71e670de29ce6000d34f3880ee">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

