### PR TITLE
FWF-6079 : [BugFix] Catastropic errors

### DIFF
--- a/forms-flow-components/src/components/CustomComponents/SelectWithCustomValue.tsx
+++ b/forms-flow-components/src/components/CustomComponents/SelectWithCustomValue.tsx
@@ -329,7 +329,7 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
                 // Do NOT auto-select the first secondary option; require user action
                 if (secondDropdown) {
                     // Clear secondary selection and wait for manual pick
-                    setSecondSelectedValue('');
+                    setSecondSelectedValue(undefined);
                 }
             },
             [onChange, secondDropdown, dependentOptions, onSecondChange, closeDropdownAndClearSearch, exitCustomMode]

--- a/forms-flow-nav/src/sidenav/Sidebar.jsx
+++ b/forms-flow-nav/src/sidenav/Sidebar.jsx
@@ -138,7 +138,7 @@ const Sidebar = React.memo(({ props, sidenavHeight="100%" }) => {
 
   const isAuthenticated = instance?.isAuthenticated();
   const showApplications = setShowApplications(userDetail?.groups);
-  const [activeKey, setActiveKey] = useState(0);
+  const [activeKey, setActiveKey] = useState(null);
   const hideLogo = StyleServices?.getCSSVariable("--hide-formsflow-logo")?.toLowerCase();
 
   // Collapsible sidebar state


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
<!-- Briefly describe the purpose of this PR and the problem it solves. -->

**Related Jira Ticket:**  
https://aottech.atlassian.net/browse/FWF-6079 (Issue 1)
https://aottech.atlassian.net/browse/FWF-6008
**Type of Change:**
- [ ] ✨ Feature
- [ ] 🐞 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 📦 Dependency Update
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config / Security Updates

---

## 🧩 Microfrontends Affected

Please select all microfrontends or modules that are part of this change:

- [ ] forms-flow-admin  
- [ ] forms-flow-components  
- [ ] forms-flow-integration  
- [ ] forms-flow-nav  
- [ ] forms-flow-review  
- [ ] forms-flow-service  
- [ ] forms-flow-submissions  
- [ ] forms-flow-theme  
- [ ] scripts  
- [ ] Others (please specify below)

**Details (if Others selected):**
<!-- Mention additional modules or new MFs impacted. -->

---

## 🧠 Summary of Changes

<!-- Provide a concise summary of what was changed, added, or removed. Include relevant technical context if necessary. -->

---

## 🧪 Testing Details

**Testing Performed:**
<!-- Describe testing done: manual, automated, cross-browser, etc. -->

**Screenshots (if applicable):**
<!-- Attach before/after screenshots or screen recordings for visual verification. -->

---

## ✅ Checklist

- [ ] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated  
- [ ] Integration or end-to-end tests validated  
- [ ] UI verified 
- [ ] Documentation updated (README / Confluence / UI Docs)  
- [ ] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [ ] I have given a **clear and meaningful PR title and description**  
- [ ] I have verified **cross-repo dependencies** (if any)  
- [ ] I have confirmed **backward compatibility** with previous releases  
- [ ] Verified changes across all selected **microfrontends**

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers (e.g., areas to focus on, specific testing steps). -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fix cleared selections using `undefined`

- Initialize sidebar active key as `null`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  selectComp["SelectWithCustomValue dependent dropdown"] 
  sidebar["Sidebar active navigation state"]
  selectComp -- "clear secondary selection" --> selectComp
  sidebar -- "no default active item" --> sidebar
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SelectWithCustomValue.tsx</strong><dd><code>Clear dependent select with undefined state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-components/src/components/CustomComponents/SelectWithCustomValue.tsx

<ul><li>Reset secondary dropdown value to <code>undefined</code><br> <li> Avoid using empty string for cleared state</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1114/files#diff-ec7b637cf48a1b97dcff8b31b330e0abaca6055ddb93e1bb6ca5cf58ed220f0d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Sidebar.jsx</strong><dd><code>Initialize sidebar activeKey without default index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-nav/src/sidenav/Sidebar.jsx

<ul><li>Change initial <code>activeKey</code> from <code>0</code> to <code>null</code><br> <li> Prevent unintended initial active navigation selection</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1114/files#diff-deefbc258e8892a956d4ef19a3bb97f554c888564b1e5e9d4bd81dc41db07299">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

