### PR TITLE
FWF-6148[bugfix] - Not clearing the variable name if they've been selected while editing on custom value field issue fixed

### DIFF
--- a/forms-flow-components/src/components/CustomComponents/SelectWithCustomValue.tsx
+++ b/forms-flow-components/src/components/CustomComponents/SelectWithCustomValue.tsx
@@ -377,14 +377,11 @@ const SelectWithCustomValueComponent = forwardRef<HTMLDivElement, SelectWithCust
 
         /** Handle special action items */
         const handleCustomValueClick = useCallback(() => {
-            // Set initial input value to current selected value if it's a string
-            if (selectedValue && typeof selectedValue === "string") {
-                enterCustomMode(selectedValue);
-            } else {
-                enterCustomMode("");
-            }
+            // Always start with empty input when entering custom value from dropdown
+            // so user can type a fresh custom value without clearing the previous selection
+            enterCustomMode("");
             onEnterCustomValue?.();
-        }, [enterCustomMode, onEnterCustomValue, selectedValue]);
+        }, [enterCustomMode, onEnterCustomValue]);
 
         const handleAdditionalVariablesClick = useCallback(() => {
             closeDropdownAndClearSearch();


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
Not clearing the variable name if they've been selected while editing on custom value field issue fixed

**Related Jira Ticket:**  
https://aottech.atlassian.net/browse/FWF-6148

**Type of Change:**
- [ ] ✨ Feature
- [x] 🐞 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 📦 Dependency Update
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config / Security Updates

---

## 🧩 Microfrontends Affected

Please select all microfrontends or modules that are part of this change:

- [ ] forms-flow-admin  
- [x] forms-flow-components  
- [ ] forms-flow-integration  
- [ ] forms-flow-nav  
- [ ] forms-flow-review  
- [ ] forms-flow-service  
- [ ] forms-flow-submissions  
- [ ] forms-flow-theme  
- [ ] scripts  
- [ ] Others (please specify below)

**Details (if Others selected):**
<!-- Mention additional modules or new MFs impacted. -->

---

## 🧠 Summary of Changes

<!-- Provide a concise summary of what was changed, added, or removed. Include relevant technical context if necessary. -->

---

## 🧪 Testing Details

**Testing Performed:**
<!-- Describe testing done: manual, automated, cross-browser, etc. -->

**Screenshots (if applicable):**
https://jam.dev/c/2a691d39-7081-4f69-a248-8713640604da

---

## ✅ Checklist

- [x] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated  
- [ ] Integration or end-to-end tests validated  
- [x] UI verified 
- [ ] Documentation updated (README / Confluence / UI Docs)  
- [ ] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [x] I have given a **clear and meaningful PR title and description**  
- [ ] I have verified **cross-repo dependencies** (if any)  
- [ ] I have confirmed **backward compatibility** with previous releases  
- [x] Verified changes across all selected **microfrontends**

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers (e.g., areas to focus on, specific testing steps). -->


___

### **PR Type**
Bug fix


___

### **Description**
- Reset custom input when entering custom mode

- Prevent stale selected value prefill


___

### Diagram Walkthrough


```mermaid
flowchart LR
  dropdown["Dropdown action: Custom value click"]
  enterCustom["enterCustomMode(\"\")"]
  typing["User types fresh custom value"]
  dropdown -- "click custom value" --> enterCustom
  enterCustom -- "shows empty input" --> typing
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SelectWithCustomValue.tsx</strong><dd><code>Clear custom input on mode entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-components/src/components/CustomComponents/SelectWithCustomValue.tsx

<ul><li>Always call <code>enterCustomMode("")</code> on custom click<br> <li> Remove prefill from <code>selectedValue</code> when entering custom mode<br> <li> Simplify hook deps by dropping <code>selectedValue</code></ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1126/files#diff-ec7b637cf48a1b97dcff8b31b330e0abaca6055ddb93e1bb6ca5cf58ed220f0d">+4/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

