### PR TITLE
Revert "FWF-6254-task-listing-for-direct-assignees"

### DIFF
--- a/forms-flow-review/src/components/TaskFilterModal/TaskFilterModalBody.tsx
+++ b/forms-flow-review/src/components/TaskFilterModal/TaskFilterModalBody.tsx
@@ -162,15 +162,9 @@ const TaskFilterModalBody = ({
 
   const getCriteria = () => {
     const criteria: FilterCriteria = {
-      orQueries: [
-        {
-          candidateGroupsExpression: "${currentUserGroups()}",
-          includeAssignedTasks: true,
-        },
-        {
-          assigneeExpression: "${currentUser()}",
-        },
-      ],
+      includeAssignedTasks: true,
+      candidateGroupsExpression: "${currentUserGroups()}",
+      // If sorting is based on submission id or form name, that should be passed as process variable in sorting
       sorting: sortValue === "applicationId" || sortValue === "formName" ?
         ([{
           sortBy: "processVariable", sortOrder: sortOrder,
@@ -178,6 +172,8 @@ const TaskFilterModalBody = ({
         }]) :
         [{ sortBy: sortValue, sortOrder: sortOrder }],
     };
+
+    
 
     if (selectedForm?.formId) {
       criteria.processVariables = [];
@@ -189,24 +185,20 @@ const TaskFilterModalBody = ({
     }
 
     if (accessOption === SPECIFIC_ROLE) {
-      const trimmedAccessValue = trimFirstSlash(accessValue);
-      const candidateGroup = addTenantPrefixIfNeeded(
-        trimmedAccessValue,
-        tenantKey,
-        MULTITENANCY_ENABLED
-      );
-      criteria.orQueries = [
-        {
-          candidateGroup: candidateGroup,
-          includeAssignedTasks: true,
-        },
-        {
-          assigneeExpression: "${currentUser()}",
-        },
-      ];
-    } else if (accessOption === SPECIFIC_ASSIGNEE) {
-      delete criteria.orQueries;
+   const trimmedAccessValue = trimFirstSlash(accessValue);
+   criteria.candidateGroup = addTenantPrefixIfNeeded(
+     trimmedAccessValue,
+     tenantKey,
+     MULTITENANCY_ENABLED
+   );
+  delete criteria.assignee;
+    } else if(accessOption === SPECIFIC_ASSIGNEE){
       criteria.assignee = accessValue;
+      delete criteria.candidateGroup;
+    }
+    else{
+      delete criteria.assignee;
+      delete criteria.candidateGroup;
     }
 
     return criteria;

--- a/forms-flow-review/src/constants/allTasksPayload.ts
+++ b/forms-flow-review/src/constants/allTasksPayload.ts
@@ -9,15 +9,8 @@ const useAllTasksPayload = () => {
   return {
     name: "All Tasks",
     criteria: {
-      orQueries: [
-        {
-          candidateGroupsExpression: "${currentUserGroups()}",
-          includeAssignedTasks: true,
-        },
-        {
-          assigneeExpression: "${currentUser()}",
-        },
-      ],
+      includeAssignedTasks: true,
+      candidateGroupsExpression: "${currentUserGroups()}",
       sorting: [
         {
           sortBy: "created",

--- a/forms-flow-review/src/helper/taskHelper.ts
+++ b/forms-flow-review/src/helper/taskHelper.ts
@@ -82,29 +82,10 @@ export const createReqPayload = (
       };
 
   const date = buildDateRangePayload(dateRange);
-
-  const criteria = clonedFilter?.criteria || {};
-
-  // Transform old-format filters (without orQueries) to use orQueries
-  // so that tasks directly assigned to the user are also returned.
-  if (!criteria.orQueries && criteria.candidateGroupsExpression) {
-    criteria.orQueries = [
-      {
-        candidateGroupsExpression: criteria.candidateGroupsExpression,
-        includeAssignedTasks: true,
-      },
-      {
-        assigneeExpression: "${ currentUser() }",
-      },
-    ];
-    delete criteria.candidateGroupsExpression;
-    delete criteria.includeAssignedTasks;
-  }
-
   const updatedFilter = {
     ...clonedFilter,
     criteria: {
-      ...criteria,
+      ...clonedFilter?.criteria,
       ...(processVariables.processVariables?.length && processVariables),
       ...(assignee.assignee && assignee),
       ...date,

--- a/forms-flow-review/src/types/taskFilter.ts
+++ b/forms-flow-review/src/types/taskFilter.ts
@@ -4,14 +4,12 @@ export interface FilterCriteria {
     includeAssignedTasks?: boolean;
     candidateGroup?: string;
     assignee?: string; 
-    assigneeExpression?: string;
     processVariables?: Array<{ 
       name: string;
       operator: string;
       value: string;
     }>;
-    candidateGroupsExpression?: string;
-    orQueries?: Array<Record<string, any>>;
+    candidateGroupsExpression: string;
     sorting: Array<{
   }>;
     createdAfter?: string;


### PR DESCRIPTION
### **User description**
Reverts AOT-Technologies/forms-flow-ai-micro-front-ends#1143


___

### **PR Type**
Other


___

### **Description**
- Revert `orQueries` task filter handling

- Restore root group-based task criteria

- Stop payload criteria normalization

- Simplify `FilterCriteria` typing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["`orQueries`-based filters"]
  B["Root group-based criteria"]
  C["Task filter modal"]
  D["All tasks payload"]
  E["Request payload builder"]
  F["Filter type definitions"]
  C -- "restored to" --> B
  D -- "restored to" --> B
  E -- "passes through" --> B
  F -- "removes support for" --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TaskFilterModalBody.tsx</strong><dd><code>Revert modal filters to root criteria</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/TaskFilterModal/TaskFilterModalBody.tsx

<ul><li>Restore top-level <code>includeAssignedTasks</code><br> <li> Restore top-level <code>candidateGroupsExpression</code><br> <li> Set <code>candidateGroup</code> for specific-role access<br> <li> Clear stale <code>assignee</code> or <code>candidateGroup</code></ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1144/files#diff-3314b3e845291ca19567f2550cdf7db70dc626d5d36f5976ee21829feecdc69b">+18/-26</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>allTasksPayload.ts</strong><dd><code>Restore all-tasks default group criteria</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/constants/allTasksPayload.ts

<ul><li>Use root <code>includeAssignedTasks</code> criteria<br> <li> Use root <code>candidateGroupsExpression</code> criteria<br> <li> Keep existing created-date sorting</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1144/files#diff-743cb25e44e09a4216d33a896cbdb31b62f610b8aa41c2b6f922e4fb5acf3768">+2/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>taskHelper.ts</strong><dd><code>Pass through existing task request criteria</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/helper/taskHelper.ts

<ul><li>Reuse <code>clonedFilter?.criteria</code> directly<br> <li> Keep merged process variable criteria<br> <li> Keep merged assignee and date filters<br> <li> Preserve sorting override construction</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1144/files#diff-de1d54213baae35eced7efa416f149b7fce8fba49c81ca0ece14345b4fb16ead">+1/-20</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>taskFilter.ts</strong><dd><code>Simplify task filter criteria typings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/types/taskFilter.ts

<ul><li>Make <code>candidateGroupsExpression</code> a direct field<br> <li> Narrow <code>FilterCriteria</code> to simpler shape</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1144/files#diff-3c0a9753e8588b398c0305c18d916545197417f71ed324fe534c28c4d364b4fa">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

