### PR TITLE
[FEATURE] FWF-6078 - Multi-Tenant Single Login

### DIFF
--- a/forms-flow-service/src/keycloak/KeycloakService.ts
+++ b/forms-flow-service/src/keycloak/KeycloakService.ts
@@ -21,12 +21,11 @@ class KeycloakService {
     url: string,
     realm: string,
     clientId: string,
-    tenantId?: string
   ) {
     this._keycloakConfig = {
       url: url,
       realm: realm,
-      clientId: tenantId ? `${tenantId}-${clientId}` : clientId,
+      clientId: clientId, // tenantId ? `${tenantId}-${clientId}` : clientId,
     };
     this.kc = new Keycloak(this._keycloakConfig);
   }
@@ -125,11 +124,10 @@ class KeycloakService {
     url: string,
     realm: string,
     clientId: string,
-    tenantId?: string
   ): KeycloakService {
     return this.instance
       ? this.instance
-      : (this.instance = new KeycloakService(url, realm, clientId, tenantId));
+      : (this.instance = new KeycloakService(url, realm, clientId));
   }
 
   /**
@@ -138,6 +136,7 @@ class KeycloakService {
    * @param callback - Optional - callback function to excecute after succeessful authentication
    */
   public initKeycloak(callback: (authenticated) => void = () => {}): void {
+
     this.kc
       ?.init(this.keycloakInitConfig)
       .then((authenticated) => {
@@ -169,6 +168,7 @@ class KeycloakService {
             }
  
           } else {
+            console.log("Token not parsed!!!!@!")
             this.logout();
           }
         } else {


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
<!-- Briefly describe the purpose of this PR and the problem it solves. -->
Unified login experience for multitenant environment

**Related Jira Ticket:**  
<!-- Jira ticket in this format : https://aottech.atlassian.net/browse/FWF-5524 -->
[](https://aottech.atlassian.net/browse/FWF-6078)
**Type of Change:**
- [x] ✨ Feature
- [ ] 🐞 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 📦 Dependency Update
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config / Security Updates

---

## 🧩 Microfrontends Affected

Please select all microfrontends or modules that are part of this change:

- [ ] forms-flow-admin  
- [ ] forms-flow-components  
- [ ] forms-flow-integration  
- [ ] forms-flow-nav  
- [ ] forms-flow-review  
- [x] forms-flow-service  
- [ ] forms-flow-submissions  
- [ ] forms-flow-theme  
- [ ] scripts  
- [ ] Others (please specify below)

**Details (if Others selected):**
<!-- Mention additional modules or new MFs impacted. -->

---

## 🧠 Summary of Changes

<!-- Provide a concise summary of what was changed, added, or removed. Include relevant technical context if necessary. -->
Updated keycloak service to always use default client and not use `${tenantId}-<default-client>`
---

## 🧪 Testing Details

**Testing Performed:**
<!-- Describe testing done: manual, automated, cross-browser, etc. -->

**Screenshots (if applicable):**
<!-- Attach before/after screenshots or screen recordings for visual verification. -->

---

## ✅ Checklist

- [ ] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated  
- [ ] Integration or end-to-end tests validated  
- [ ] UI verified 
- [ ] Documentation updated (README / Confluence / UI Docs)  
- [ ] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [ ] I have given a **clear and meaningful PR title and description**  
- [ ] I have verified **cross-repo dependencies** (if any)  
- [ ] I have confirmed **backward compatibility** with previous releases  
- [ ] Verified changes across all selected **microfrontends**

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers (e.g., areas to focus on, specific testing steps). -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Use shared Keycloak client across tenants

- Remove `tenantId` from service creation

- Log token parse failures before logout


___

### Diagram Walkthrough


```mermaid
flowchart LR
  app["App startup"]
  instance["KeycloakService.getInstance"]
  config["Default clientId configuration"]
  auth["Keycloak authentication"]
  log["Token parse failure logging"]
  app -- "requests service" --> instance
  instance -- "creates with" --> config
  config -- "used by" --> auth
  auth -- "on parse failure" --> log
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KeycloakService.ts</strong><dd><code>Simplify Keycloak client selection for tenants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-service/src/keycloak/KeycloakService.ts

<ul><li>Removed <code>tenantId</code> from the constructor signature<br> <li> Removed <code>tenantId</code> from <code>getInstance</code> parameters<br> <li> Always sets Keycloak <code>clientId</code> to the default value<br> <li> Added a console log before logout on token parse failure</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1147/files#diff-ea388c91be94bab26b037cc2d38905975aeda529fc94edb85e7813a2d191953c">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

