### PR TITLE
FWF-6471 : [Feature] Organization page changes to replace trial with go

### DIFF
--- a/forms-flow-admin/src/components/organization/index.tsx
+++ b/forms-flow-admin/src/components/organization/index.tsx
@@ -97,7 +97,7 @@ function resolveSubscriptionUiKind(
     return "active";
   }
   if(!status) {
-    return "expired";
+    return "trial";
   }
 
   const trialExpiry = parseTenantDateTime(tenant?.trial_expiry_dt);
@@ -133,18 +133,18 @@ function getSubscriptionPresentation(
       };
     case "trial":
       return {
-        title: t("Trial"),
-        description: `You have ${daysDifference ?? 0} days left of your free trial.`,
+        title: t("Go"),
+        description: "You are currently using a free version of formsflow.",
       };
     case "expired":
       return {
-        title: t("Expired"),
-        description: "",
+        title: t("Go"),
+        description: "You are currently using a free version of formsflow.",
       };
     case "cancelled":
       return {
-        title: t("Cancelled"),
-        description: "",
+        title: t("Go"),
+        description: "You are currently using a free version of formsflow.",
       };
     case "none":
       return {
@@ -200,7 +200,7 @@ const Organization: React.FC<any> = (props) => {
       const tenantDataStr = StorageService.get("tenantData");
       if (!tenantDataStr) {
         setDaysDifference(null);
-        setSubscriptionKind("expired");
+        setSubscriptionKind("trial");
         return;
       }
       try {

--- a/forms-flow-admin/src/components/organization/index.tsx
+++ b/forms-flow-admin/src/components/organization/index.tsx
@@ -132,24 +132,11 @@ function getSubscriptionPresentation(
         description: t("You are currently using a paid version of formsflow."),
       };
     case "trial":
-      return {
-        title: t("Go"),
-        description: "You are currently using a free version of formsflow.",
-      };
     case "expired":
-      return {
-        title: t("Go"),
-        description: "You are currently using a free version of formsflow.",
-      };
     case "cancelled":
       return {
         title: t("Go"),
         description: "You are currently using a free version of formsflow.",
-      };
-    case "none":
-      return {
-        title: "",
-        description: "",
       };
     default:
       return { title: "", description: "" };


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
<!-- Briefly describe the purpose of this PR and the problem it solves. -->

**Related Jira Ticket:**  
https://aottech.atlassian.net/browse/FWF-6471

**Type of Change:**
- [ ] ✨ Feature
- [ ] 🐞 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 📦 Dependency Update
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config / Security Updates

---

## 🧩 Microfrontends Affected

Please select all microfrontends or modules that are part of this change:

- [ ] forms-flow-admin  
- [ ] forms-flow-components  
- [ ] forms-flow-integration  
- [ ] forms-flow-nav  
- [ ] forms-flow-review  
- [ ] forms-flow-service  
- [ ] forms-flow-submissions  
- [ ] forms-flow-theme  
- [ ] scripts  
- [ ] Others (please specify below)

**Details (if Others selected):**
<!-- Mention additional modules or new MFs impacted. -->

---

## 🧠 Summary of Changes

<!-- Provide a concise summary of what was changed, added, or removed. Include relevant technical context if necessary. -->

---

## 🧪 Testing Details

**Testing Performed:**
<!-- Describe testing done: manual, automated, cross-browser, etc. -->

**Screenshots (if applicable):**
<img width="1119" height="788" alt="image" src="https://github.com/user-attachments/assets/61c4a702-1a60-4ad3-a075-3122c80c8fa1" />

<img width="1204" height="783" alt="image" src="https://github.com/user-attachments/assets/14a88535-44c0-4018-a728-2668501aebe5" />

---

## ✅ Checklist

- [ ] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated  
- [ ] Integration or end-to-end tests validated  
- [ ] UI verified 
- [ ] Documentation updated (README / Confluence / UI Docs)  
- [ ] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [ ] I have given a **clear and meaningful PR title and description**  
- [ ] I have verified **cross-repo dependencies** (if any)  
- [ ] I have confirmed **backward compatibility** with previous releases  
- [ ] Verified changes across all selected **microfrontends**

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers (e.g., areas to focus on, specific testing steps). -->


___

### **PR Type**
Enhancement


___

### **Description**
- Replace trial states with Go messaging

- Treat missing subscription as trial/free

- Show free formsflow version description


___

### Diagram Walkthrough


```mermaid
flowchart LR
  tenant["Tenant subscription data"]
  resolver["Subscription UI kind resolver"]
  presentation["Subscription presentation"]
  ui["Organization subscription card"]
  tenant -- "missing status defaults" --> resolver
  resolver -- "trial/expired/cancelled" --> presentation
  presentation -- "shows Go free plan" --> ui
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Update organization subscription Go messaging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-admin/src/components/organization/index.tsx

<ul><li>Defaults missing subscription status to <code>trial</code>.<br> <li> Defaults missing <code>tenantData</code> storage to <code>trial</code>.<br> <li> Maps <code>trial</code>, <code>expired</code>, and <code>cancelled</code> states to <code>Go</code>.<br> <li> Displays free formsflow version messaging.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1225/files#diff-740eebff08246574983f173af9897095c35fbdfdb7b7b8c5c1a1fc5d1947a2d9">+4/-17</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

