### PR TITLE
FWF-6453 [Bugfix] Userlist filtering issue resolved with blank row removal cases as well

### DIFF
--- a/forms-flow-review/src/components/Assigne/Assigne.tsx
+++ b/forms-flow-review/src/components/Assigne/Assigne.tsx
@@ -9,6 +9,7 @@ import {
   unClaimBPMTask,
   updateAssigneeBPMTask,
   fetchUsersByMemberOfGroup,
+  fetchUserList,
 } from "../../api/services/filterServices";
 import {  setTaskDetailsLoading } from "../../actions/taskActions";
 import { getBPMTaskDetail } from "../../api/services/bpmTaskServices";
@@ -25,6 +26,8 @@ import {
 import { useCallback, useEffect, useMemo, useState, useRef } from "react";
 
 
+
+const ROLE_VIEW_TASKS = "ROLE_view_tasks";
 
 const TaskAssigneeManager = ({ task, isFromTaskDetails=false, minimized=false, resizable=false }) => {
   const dispatch = useAppDispatch();
@@ -106,16 +109,38 @@ const TaskAssigneeManager = ({ task, isFromTaskDetails=false, minimized=false, r
     setMemberGroupOptions([]);
   }, [taskId, candidateGroupKey]);
 
+  // ROLE_view_tasks isn't a real member-of-group in Keycloak, so fetchUsersByMemberOfGroup
+  // would return no results for it. Reuse fetchUserList (permission=manage_tasks) instead,
+  // wrapping its (dispatch, callback) thunk shape into a promise that matches
+  // fetchUsersByMemberOfGroup's response shape so both can feed mergeMemberOfGroupResponsesToSelectOptions.
+  const fetchUsersForRoleViewTasks = useCallback(
+    () =>
+      new Promise<{ data: any }>((resolve, reject) => {
+        dispatch(
+          fetchUserList((err: any, data: any) => {
+            if (err) reject(err);
+            else resolve({ data });
+          })
+        );
+      }),
+    [dispatch]
+  );
+
   const handleAssigneeOpen = useCallback(() => {
     const ids = resolveTaskCandidateGroupIds(effectiveTask, task);
     if (ids.length === 0) return;
-    void Promise.all(ids.map((g) => fetchUsersByMemberOfGroup(g)))
+    void Promise.all(
+      ids.map((g) =>
+        // ROLE_view_tasks uses a different lookup; all other candidate groups are unchanged.
+        g === ROLE_VIEW_TASKS ? fetchUsersForRoleViewTasks() : fetchUsersByMemberOfGroup(g)
+      )
+    )
       .then((responses) => mergeMemberOfGroupResponsesToSelectOptions(responses))
       .then((sorted) => {
         setMemberGroupOptions(sorted);
       })
       .catch(() => undefined);
-  }, [effectiveTask, task]);
+  }, [effectiveTask, task, fetchUsersForRoleViewTasks]);
   
   const handleChangeClaim = (newuser: string) => {
     // Optimistically update the UI label

--- a/forms-flow-review/src/helper/assigneeCandidateGroups.ts
+++ b/forms-flow-review/src/helper/assigneeCandidateGroups.ts
@@ -72,10 +72,13 @@ export function mapMemberOfGroupUsersToSelectOptions(
   const opts = rows
     .map((r) => {
       const username = r.username == null ? "" : String(r.username).trim();
-      if (username) {
+      // Keycloak service accounts (e.g. "service-account-devtest-form...") aren't real assignees.
+      if (username && !username.startsWith("service-account-")) {
         const firstName = r.firstName == null ? "" : String(r.firstName).trim();
         const lastName = r.lastName == null ? "" : String(r.lastName).trim();
-        return { label: formatLastCommaFirst(firstName, lastName), value: username };
+        // Fall back to username so users with no name on file don't render as a blank row.
+        const label = formatLastCommaFirst(firstName, lastName) || username;
+        return { label, value: username };
       }
       return null;
     })


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**

- Assignee dropdown fetches candidate users per candidate group via fetchUsersByMemberOfGroup. ROLE_view_tasks isn't a real Keycloak group, so that lookup returned no users for tasks carrying that candidate group — the dropdown showed only  "Assign to me"/"Unassigned". For ROLE_view_tasks specifically, we now fetch via fetchUserList (permission=manage_tasks) instead, wrapping its dispatch/callback shape into a promise compatible with the existing merge pipeline. All other candidate groups are unaffected.
- Users with no firstName/lastName on record rendered as blank rows in the dropdown. The label now falls back to username when both names are empty.
- Keycloak service-account users (e.g. service-account-devtest-formsflow...) were showing up as selectable assignees. These are now filtered out of the dropdown options entirely.


**Related Jira Ticket:**  
https://aottech.atlassian.net/browse/FWF-6453

**Type of Change:**
- [ ] ✨ Feature
- [x] 🐞 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 📦 Dependency Update
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config / Security Updates

---

## 🧩 Microfrontends Affected

Please select all microfrontends or modules that are part of this change:

- [ ] forms-flow-admin  
- [ ] forms-flow-components  
- [ ] forms-flow-integration  
- [ ] forms-flow-nav  
- [x] forms-flow-review  
- [ ] forms-flow-service  
- [ ] forms-flow-submissions  
- [ ] forms-flow-theme  
- [ ] scripts  
- [ ] Others (please specify below)

**Details (if Others selected):**
<!-- Mention additional modules or new MFs impacted. -->

---

## 🧠 Summary of Changes

<!-- Provide a concise summary of what was changed, added, or removed. Include relevant technical context if necessary. -->

---

## 🧪 Testing Details

**Testing Performed:**
<!-- Describe testing done: manual, automated, cross-browser, etc. -->

**Screenshots (if applicable):**
<!-- Attach before/after screenshots or screen recordings for visual verification. -->

---

## ✅ Checklist

- [ ] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated  
- [ ] Integration or end-to-end tests validated  
- [ ] UI verified 
- [ ] Documentation updated (README / Confluence / UI Docs)  
- [ ] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [x] I have given a **clear and meaningful PR title and description**  
- [ ] I have verified **cross-repo dependencies** (if any)  
- [ ] I have confirmed **backward compatibility** with previous releases  
- [ ] Verified changes across all selected **microfrontends**

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers (e.g., areas to focus on, specific testing steps). -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fix `ROLE_view_tasks` assignee lookup

- Hide service-account users from assignees

- Prevent blank assignee dropdown rows


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Candidate groups"] -- "resolve ids" --> B["Assignee dropdown"]
  B -- "ROLE_view_tasks" --> C["fetchUserList"]
  B -- "Other groups" --> D["fetchUsersByMemberOfGroup"]
  C -- "merge options" --> E["Filtered user options"]
  D -- "merge options" --> E
  E -- "remove service accounts" --> F["Selectable assignees"]
  E -- "fallback labels" --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Assigne.tsx</strong><dd><code>Resolve `ROLE_view_tasks` assignee lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/components/Assigne/Assigne.tsx

<ul><li>Imports <code>fetchUserList</code> for alternate user lookup.<br> <li> Adds <code>ROLE_VIEW_TASKS</code> candidate group constant.<br> <li> Wraps <code>fetchUserList</code> callback API in a promise.<br> <li> Uses alternate lookup only for <code>ROLE_view_tasks</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1237/files#diff-7f6a175af653419a64a18a250984a2d78620efb492bc27d0136b1d40b93682a8">+27/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>assigneeCandidateGroups.ts</strong><dd><code>Filter and label assignee options safely</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-review/src/helper/assigneeCandidateGroups.ts

<ul><li>Filters out Keycloak <code>service-account-</code> users.<br> <li> Falls back to username for missing names.<br> <li> Prevents blank assignee option labels.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1237/files#diff-f91d0e1f68e6ebfde4735c9d16e5e14b5fd3e9e0656a289552178a877d924748">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

