### PR TITLE
FWF-6547:[Bugfix] Render bundle submissions in analyze history modal

### DIFF
--- a/forms-flow-submissions/src/components/AnalyzeSubmissionView.tsx
+++ b/forms-flow-submissions/src/components/AnalyzeSubmissionView.tsx
@@ -237,7 +237,10 @@ const ViewApplication = React.memo(() => {
     const { formId, submissionId } = data;
     setSelectedSubmissionData(data);
     setShowFormModal(true);
-    
+    if(!formId || !submissionId) return;
+  
+    if (formType === "bundle") return;
+
     // Load form and submission data
     if (formId && submissionId) {
       Formio.clearCache();
@@ -249,7 +252,7 @@ const ViewApplication = React.memo(() => {
         dispatch(getSubmission("submission", submissionId, formId));
       }
     }
-  }, [dispatch]);
+  }, [dispatch, formType]);
 
   // Prepare history table data - must be before early return (Rules of Hooks)
   const historyColumns = useMemo(
@@ -312,6 +315,16 @@ const ViewApplication = React.memo(() => {
       },
     ],
     [t, viewSubmission, dispatch, applicationId]
+  );
+
+  // Stable object for the modal's BundleSubmissionView. BundleSubmissionView's
+  // data-fetch effect depends on this by reference, so passing a fresh object
+  const modalBundleFormData = useMemo(
+    () => ({
+      formId: selectedSubmissionData?.formId ?? "",
+      submissionId: selectedSubmissionData?.submissionId ?? "",
+    }),
+    [selectedSubmissionData?.formId, selectedSubmissionData?.submissionId]
   );
 
   const historyRows = useMemo(() => {
@@ -486,7 +499,14 @@ const ViewApplication = React.memo(() => {
           title={selectedSubmissionData?.created ? HelperServices.getLocaldate(selectedSubmissionData.created) : ""}
         >
         {selectedSubmissionData && (
-            <View page="application-detail" />
+            formType === "bundle" ? (
+              <BundleSubmissionView
+                key={selectedSubmissionData.submissionId}
+                bundleFormData={modalBundleFormData}
+              />
+            ) : (
+              <View page="application-detail" />
+            )
           )}
         </FormViewModal>
     </div>

--- a/forms-flow-submissions/src/components/BundleSubmissionView.tsx
+++ b/forms-flow-submissions/src/components/BundleSubmissionView.tsx
@@ -128,6 +128,7 @@ const BundleSubmissionForm: React.FC<TaskFormProps> = ({
         variant="medium"
         activeIndex={formStep}
         onBreadcrumbClick={(item: { id?: string; label: string }) => onLabelClick(Number(item.id))}
+        className="bundle-view-breadcumbs"
       />
   
       <div className="p-3 analyze-Submission-bundle-view ">

--- a/forms-flow-theme/scss/historyModal.scss
+++ b/forms-flow-theme/scss/historyModal.scss
@@ -141,3 +141,9 @@ $white-color: var(--ff-white);
 .analyse-submision-history-modal{
   min-height: 80vh;
 }
+
+.form-view-modal-body {
+  .bundle-view-breadcumbs {
+    padding-top: 1rem !important;
+  }
+}


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
The submission history/analyze modal did not render bundle submissions — for a
`bundle` form type it fell through to the generic application-detail view and
showed nothing. This renders the bundle in the modal via `BundleSubmissionView`
and short-circuits the non-bundle data fetch.


**Related Jira Ticket:**  
https://aottech.atlassian.net/browse/FWF-6547

**Type of Change:**
- [ ] ✨ Feature
- [x] 🐞 Bug Fix
- [x] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 📦 Dependency Update
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config / Security Updates

---

## 🧩 Microfrontends Affected

Please select all microfrontends or modules that are part of this change:

- [ ] forms-flow-admin  
- [ ] forms-flow-components  
- [ ] forms-flow-integration  
- [ ] forms-flow-nav  
- [ ] forms-flow-review  
- [ ] forms-flow-service  
- [ ] forms-flow-submissions  
- [ ] forms-flow-theme  
- [ ] scripts  
- [ ] Others (please specify below)

**Details (if Others selected):**
<!-- Mention additional modules or new MFs impacted. -->

---

## 🧠 Summary of Changes

<!-- Provide a concise summary of what was changed, added, or removed. Include relevant technical context if necessary. -->

---

## 🧪 Testing Details

**Testing Performed:**
<!-- Describe testing done: manual, automated, cross-browser, etc. -->

**Screenshots (if applicable):**
<!-- Attach before/after screenshots or screen recordings for visual verification. -->

---

## ✅ Checklist

- [ ] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated  
- [ ] Integration or end-to-end tests validated  
- [ ] UI verified 
- [ ] Documentation updated (README / Confluence / UI Docs)  
- [ ] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [ ] I have given a **clear and meaningful PR title and description**  
- [ ] I have verified **cross-repo dependencies** (if any)  
- [ ] I have confirmed **backward compatibility** with previous releases  
- [ ] Verified changes across all selected **microfrontends**

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers (e.g., areas to focus on, specific testing steps). -->


___

### **PR Type**
Bug fix


___

### **Description**
- Render bundle history submissions correctly

- Skip non-bundle submission fetching for bundles

- Add bundle modal breadcrumb spacing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["History row click"] -- "stores selected submission" --> B["Form modal opens"]
  B -- "bundle form type" --> C["BundleSubmissionView"]
  B -- "other form types" --> D["Application detail view"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AnalyzeSubmissionView.tsx</strong><dd><code>Render bundle submissions in history modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-submissions/src/components/AnalyzeSubmissionView.tsx

<ul><li>Opens the history modal before validating submission identifiers.<br> <li> Short-circuits form/submission fetching when <code>formType</code> is <code>bundle</code>.<br> <li> Adds memoized <code>modalBundleFormData</code> for stable <code>BundleSubmissionView</code> <br>props.<br> <li> Renders <code>BundleSubmissionView</code> for bundle submissions instead of <code>View</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1263/files#diff-b150392450c335180794241678966da2eac3530fb2a1c5887427298b61b41743">+23/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BundleSubmissionView.tsx</strong><dd><code>Add bundle breadcrumb styling hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-submissions/src/components/BundleSubmissionView.tsx

<ul><li>Adds <code>bundle-view-breadcumbs</code> class to the bundle breadcrumbs component.<br> <li> Enables targeted styling when rendered inside the modal.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1263/files#diff-5a3c9eaec41f444b2a5bedf3f983c3cdefc5b2725516648707913ee14cded8eb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>historyModal.scss</strong><dd><code>Style bundle breadcrumbs in modal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-theme/scss/historyModal.scss

<ul><li>Adds modal-specific top padding for <code>.bundle-view-breadcumbs</code>.<br> <li> Improves bundle breadcrumb spacing within <code>.form-view-modal-body</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1263/files#diff-21e03e368c486012a595293d019220b38aa0a7f354a0c5a7d36189db53dc956a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

