### PR TITLE
FWF-6548:[Bugfix] Show Flow tab only for BPMN workflows in Analyze submission

### DIFF
--- a/forms-flow-submissions/src/components/AnalyzeSubmissionView.tsx
+++ b/forms-flow-submissions/src/components/AnalyzeSubmissionView.tsx
@@ -357,7 +357,12 @@ const ViewApplication = React.memo(() => {
     // Filter out Flow tab if processType is not BPMN
     return tabs.filter(tab => {
       if (tab.id === "flow") {
-        return processType !== "LOWCODE";
+        // Quickfix
+        // Only show the Flow tab when the attached workflow is BPMN.
+        // Non-BPMN workflows (LOWCODE/nocode or defaultworkflow) including bundles
+        // whose process type is unset — have no diagram, so the tab must be
+        // hidden entirely instead of rendered as an empty/broken tab.
+        return processType === "BPMN";
       }
       return true;
     });


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
In Analyze → Submissions, the FLOW tab was shown for non-BPMN workflows (nocode/default), including bundles whose process type is unset, rendering an empty/broken tab with no process diagram. This restricts the FLOW tab to BPMN workflows only.

**Related Jira Ticket:**  
https://aottech.atlassian.net/browse/FWF-6548

**Type of Change:**
- [ ] ✨ Feature
- [x] 🐞 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 📦 Dependency Update
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config / Security Updates

---

## 🧩 Microfrontends Affected

Please select all microfrontends or modules that are part of this change:

- [ ] forms-flow-admin  
- [ ] forms-flow-components  
- [ ] forms-flow-integration  
- [ ] forms-flow-nav  
- [ ] forms-flow-review  
- [ ] forms-flow-service  
- [ ] forms-flow-submissions  
- [ ] forms-flow-theme  
- [ ] scripts  
- [ ] Others (please specify below)

**Details (if Others selected):**
<!-- Mention additional modules or new MFs impacted. -->

---

## 🧠 Summary of Changes

<!-- Provide a concise summary of what was changed, added, or removed. Include relevant technical context if necessary. -->

---

## 🧪 Testing Details

**Testing Performed:**
<!-- Describe testing done: manual, automated, cross-browser, etc. -->

**Screenshots (if applicable):**
<!-- Attach before/after screenshots or screen recordings for visual verification. -->

---

## ✅ Checklist

- [ ] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated  
- [ ] Integration or end-to-end tests validated  
- [ ] UI verified 
- [ ] Documentation updated (README / Confluence / UI Docs)  
- [ ] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [ ] I have given a **clear and meaningful PR title and description**  
- [ ] I have verified **cross-repo dependencies** (if any)  
- [ ] I have confirmed **backward compatibility** with previous releases  
- [ ] Verified changes across all selected **microfrontends**

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers (e.g., areas to focus on, specific testing steps). -->


___

### **PR Type**
Bug fix


___

### **Description**
- Restricts Flow tab to BPMN workflows

- Hides empty tabs for non-BPMN submissions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Analyze submission"] -- "checks processType" --> B["BPMN workflow"]
  A -- "non-BPMN or unset" --> C["Hide Flow tab"]
  B -- "has diagram" --> D["Show Flow tab"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AnalyzeSubmissionView.tsx</strong><dd><code>Restrict Flow tab to BPMN workflows</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-submissions/src/components/AnalyzeSubmissionView.tsx

<ul><li>Updates Flow tab filtering logic.<br> <li> Shows Flow tab only when <code>processType === "BPMN"</code>.<br> <li> Hides Flow tab for LOWCODE, nocode, default, or unset process types.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1268/files#diff-b150392450c335180794241678966da2eac3530fb2a1c5887427298b61b41743">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

