### PR TITLE
Revert "FWF-6547 : [Hotfix] Added hotfix for bundle workflow issues"

### DIFF
--- a/forms-flow-submissions/src/components/AnalyzeSubmissionView.tsx
+++ b/forms-flow-submissions/src/components/AnalyzeSubmissionView.tsx
@@ -301,18 +301,17 @@ const ViewApplication = React.memo(() => {
         cellClassName: "sticky-column-cell",
   
         width: 100,
-        renderCell: (params: any) =>
-          formType === "bundle" ? null : (
-            <V8CustomButton
-              label={t("View")}
-              dataTestId="task-view-button"
-              variant="secondary"
-              onClick={() => viewSubmission(params.row)}
-            />
-          ),
+        renderCell: (params: any) => (
+          <V8CustomButton
+            label={t("View")}
+            dataTestId="task-view-button"
+            variant="secondary"
+            onClick={() => viewSubmission(params.row)}
+          />
+        ),
       },
     ],
-    [t, viewSubmission, dispatch, applicationId, formType]
+    [t, viewSubmission, dispatch, applicationId]
   );
 
   const historyRows = useMemo(() => {
@@ -332,10 +331,10 @@ const ViewApplication = React.memo(() => {
         label: t(formType === "bundle" ? "Bundle" : "Form"),
         id: "form",
       },
-      // {
-      //   label: t("Flow"),
-      //   id: "flow",
-      // },
+      {
+        label: t("Flow"),
+        id: "flow",
+      },
       {
         label: t("History"),
         id: "history",
@@ -343,14 +342,13 @@ const ViewApplication = React.memo(() => {
     ];
 
     // Filter out Flow tab if processType is not BPMN
-    // return tabs.filter(tab => {
-    //   if (tab.id === "flow") {
-    //     return processType !== "LOWCODE";
-    //   }
-    //   return true;
-    // });
-    return tabs;
-  }, [t, formType]);
+    return tabs.filter(tab => {
+      if (tab.id === "flow") {
+        return processType !== "LOWCODE";
+      }
+      return true;
+    });
+  }, [t, processType, formType]);
 
   if (isApplicationDetailLoading) {
     return <Loading />;


### PR DESCRIPTION
### **User description**
Reverts AOT-Technologies/forms-flow-ai-micro-front-ends#1264


___

### **PR Type**
Bug fix


___

### **Description**
- Restore history `View` action

- Re-enable conditional `Flow` tab

- Update tab memoization dependencies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  view["Submission history table"]
  action["View action button"]
  tabs["Submission detail tabs"]
  flow["Flow tab"]
  process["Process type"]
  view -- "always shows" --> action
  tabs -- "includes" --> flow
  process -- "hides Flow for LOWCODE" --> flow
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AnalyzeSubmissionView.tsx</strong><dd><code>Restore Flow tab and history View button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-submissions/src/components/AnalyzeSubmissionView.tsx

<ul><li>Restores the history row <code>View</code> button for all form types.<br> <li> Removes <code>formType</code> from history column memo dependencies.<br> <li> Re-adds the <code>Flow</code> tab to the tab configuration.<br> <li> Restores filtering that hides <code>Flow</code> only for <code>LOWCODE</code> process types.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1269/files#diff-b150392450c335180794241678966da2eac3530fb2a1c5887427298b61b41743">+20/-22</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

