### PR TITLE
FWF-6555:[bugfix]Fixed bundle export issue

### DIFF
--- a/forms-flow-submissions/src/components/AnalyzeSubmissionView.tsx
+++ b/forms-flow-submissions/src/components/AnalyzeSubmissionView.tsx
@@ -95,6 +95,7 @@ const ViewApplication = React.memo(() => {
   });
 
   const [formType, setFormType] = useState('');
+  const [bundleMapperId, setBundleMapperId] = useState('');
   const [processType, setProcessType] = useState<string | undefined>(undefined);
   const [selectedTab, setSelectedTab] = useState({ id: "form", label: t("Form") });
   const [showExportAlert, setShowExportAlert] = useState(false);
@@ -150,7 +151,7 @@ const ViewApplication = React.memo(() => {
   
         if (formType === "bundle") {
           setBundleLoading(true);
-  
+          setBundleMapperId(res.data.id);
           executeRule(
             {
               submissionType: "fetch",
@@ -486,6 +487,9 @@ const ViewApplication = React.memo(() => {
               onPreDownload={handlePreDownload}
               onPostDownload={handlePostDownload}
               disabled={selectedTab?.id === "flow"}
+              {...(formType === "bundle"
+                ? { isBundle: true, bundleId: bundleMapperId }
+                : {})}
             />
           </div>
             )}


### PR DESCRIPTION
### **User description**
## 📝 Pull Request Summary

**Description:**
bundle submissions exported as PDF came out blank because the Analyze Submission
export button sent only form_id and submission_id, with no bundle context. This
passes isBundle and the form-process mapperId (captured from the same fetchFormVariables
call used to load the bundle) to DownloadPDFButton for bundle form types, so the
backend receives the mapperId/isBundle query params needed to render the bundle's forms.

**Related Jira Ticket:**  
https://aottech.atlassian.net/browse/FWF-6555

**Type of Change:**
- [ ] ✨ Feature
- [x] 🐞 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🧹 Code Cleanup
- [ ] 🧪 Test Addition / Update
- [ ] 📦 Dependency Update
- [ ] 📘 Documentation Update
- [ ] 🚀 Deployment / Config / Security Updates

---

## 🧩 Microfrontends Affected

Please select all microfrontends or modules that are part of this change:

- [ ] forms-flow-admin  
- [ ] forms-flow-components  
- [ ] forms-flow-integration  
- [ ] forms-flow-nav  
- [ ] forms-flow-review  
- [ ] forms-flow-service  
- [ ] forms-flow-submissions  
- [ ] forms-flow-theme  
- [ ] scripts  
- [ ] Others (please specify below)

**Details (if Others selected):**
<!-- Mention additional modules or new MFs impacted. -->

---

## 🧠 Summary of Changes

<!-- Provide a concise summary of what was changed, added, or removed. Include relevant technical context if necessary. -->

---

## 🧪 Testing Details

**Testing Performed:**
<!-- Describe testing done: manual, automated, cross-browser, etc. -->

**Screenshots (if applicable):**
<!-- Attach before/after screenshots or screen recordings for visual verification. -->

---

## ✅ Checklist

- [ ] Code builds successfully without lint or type errors  
- [ ] Unit tests added or updated  
- [ ] Integration or end-to-end tests validated  
- [ ] UI verified 
- [ ] Documentation updated (README / Confluence / UI Docs)  
- [ ] No sensitive information (keys, passwords, secrets) committed  
- [ ] I have updated the **CHANGELOG** with relevant details  
- [ ] I have given a **clear and meaningful PR title and description**  
- [ ] I have verified **cross-repo dependencies** (if any)  
- [ ] I have confirmed **backward compatibility** with previous releases  
- [ ] Verified changes across all selected **microfrontends**

---

## 👥 Reviewer Notes

<!-- Optional: Add context or special instructions for reviewers (e.g., areas to focus on, specific testing steps). -->


___

### **PR Type**
Bug fix


___

### **Description**
- Pass bundle context to PDF downloads

- Store mapper ID from form variables

- Preserve standard export behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Form variables"] -- "provide mapper ID" --> B["Bundle state"]
  B -- "bundleId and isBundle" --> C["DownloadPDFButton"]
  C -- "backend receives context" --> D["Bundle PDF export"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AnalyzeSubmissionView.tsx</strong><dd><code>Add bundle context to PDF downloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

forms-flow-submissions/src/components/AnalyzeSubmissionView.tsx

<ul><li>Adds <code>bundleMapperId</code> state for bundle exports.<br> <li> Captures mapper ID from <code>fetchFormVariables</code> response.<br> <li> Passes <code>isBundle</code> and <code>bundleId</code> to <code>DownloadPDFButton</code>.<br> <li> Applies bundle props only for bundle form types.</ul>


</details>


  </td>
  <td><a href="https://github.com/AOT-Technologies/forms-flow-ai-micro-front-ends/pull/1271/files#diff-b150392450c335180794241678966da2eac3530fb2a1c5887427298b61b41743">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

